### PR TITLE
Resolved issue #12 (Program sometimes crashes if it runs in parallel, and "exit_now" is created.)

### DIFF
--- a/Sources/Process/Main_Pro.f90
+++ b/Sources/Process/Main_Pro.f90
@@ -461,13 +461,17 @@
     call User_Mod_End_Of_Time_Step(grid, n, time)
 
     if(save_now) then
-      open (9, file='save_now', status='old')
-      close(9, status='delete')
+      if(this_proc < 2) then
+        open (9, file='save_now', status='old')
+        close(9, status='delete')
+      end if
     end if
 
     if(exit_now) then
-      open (9, file='exit_now', status='old')
-      close(9, status='delete')
+      if(this_proc < 2) then
+        open (9, file='exit_now', status='old')
+        close(9, status='delete')
+      end if
       goto 2
     end if
 


### PR DESCRIPTION
The trouble was that more than one processors were trying to delete file "exit_now".  I restricted this action to one processor only.