### PR TITLE
Issue #16 (BUG) Reynolds stresses not save in backup files

### DIFF
--- a/Sources/Process/Load_Backup.f90
+++ b/Sources/Process/Load_Backup.f90
@@ -123,6 +123,29 @@
     call Read_Backup_Cell_Bnd(fh, d, 'l_scale',  l_scale(-nb_s:nc_s))
   end if 
 
+  if(turbulence_model .eq. REYNOLDS_STRESS .or.  &                          
+     turbulence_model .eq. HANJALIC_JAKIRLIC) then                          
+
+    ! Reynolds stresses
+    call Read_Backup_Variable(fh, d, 'uu',  uu)
+    call Read_Backup_Variable(fh, d, 'vv',  vv)
+    call Read_Backup_Variable(fh, d, 'ww',  ww)
+    call Read_Backup_Variable(fh, d, 'uv',  uv)
+    call Read_Backup_Variable(fh, d, 'uw',  uw)
+    call Read_Backup_Variable(fh, d, 'vw',  vw)
+
+    ! K and epsilon
+    call Read_Backup_Variable(fh, d, 'kin', kin)
+    call Read_Backup_Variable(fh, d, 'eps', eps)
+
+    ! F22
+    if(turbulence_model .eq. HANJALIC_JAKIRLIC) then
+      call Read_Backup_Variable(fh, d, 'f22',  f22)
+    end if
+
+    ! Other turbulent quantities ?
+  end if 
+
   ! Close backup file
   call Comm_Mod_Close_File(fh)
 

--- a/Sources/Process/Save_Backup.f90
+++ b/Sources/Process/Save_Backup.f90
@@ -119,6 +119,29 @@
     call Write_Backup_Cell_Bnd(fh, d, 'l_scale',  l_scale(-nb_s:nc_s))
   end if 
 
+  if(turbulence_model .eq. REYNOLDS_STRESS .or.  &                          
+     turbulence_model .eq. HANJALIC_JAKIRLIC) then                          
+
+    ! Reynolds stresses
+    call Write_Backup_Variable(fh, d, 'uu',  uu)
+    call Write_Backup_Variable(fh, d, 'vv',  vv)
+    call Write_Backup_Variable(fh, d, 'ww',  ww)
+    call Write_Backup_Variable(fh, d, 'uv',  uv)
+    call Write_Backup_Variable(fh, d, 'uw',  uw)
+    call Write_Backup_Variable(fh, d, 'vw',  vw)
+
+    ! K and epsilon
+    call Write_Backup_Variable(fh, d, 'kin', kin)
+    call Write_Backup_Variable(fh, d, 'eps', eps)
+
+    ! F22
+    if(turbulence_model .eq. HANJALIC_JAKIRLIC) then
+      call Write_Backup_Variable(fh, d, 'f22',  f22)
+    end if
+
+    ! Other turbulent quantities ?
+  end if 
+
   ! Close backup file
   call Comm_Mod_Close_File(fh)
 

--- a/Sources/Process/Update_Boundary_Values.f90
+++ b/Sources/Process/Update_Boundary_Values.f90
@@ -109,14 +109,14 @@
         if(Grid_Mod_Bnd_Cond_Type(grid,c2) .eq. OUTFLOW .or.  &
            Grid_Mod_Bnd_Cond_Type(grid,c2) .eq. CONVECT .or.  &
            Grid_Mod_Bnd_Cond_Type(grid,c2) .eq. PRESSURE) then
+          uu  % n(c2) = uu  % n(c1)
+          vv  % n(c2) = vv  % n(c1)
+          ww  % n(c2) = ww  % n(c1)
+          uv  % n(c2) = uv  % n(c1)
+          uw  % n(c2) = uw  % n(c1)
+          vw  % n(c2) = vw  % n(c1)
           kin % n(c2) = kin % n(c1)
           eps % n(c2) = eps % n(c1)
-          uu % n(c2) = uu % n(c1)
-          vv % n(c2) = vv % n(c1)
-          ww % n(c2) = ww % n(c1)
-          uv % n(c2) = uv % n(c1)
-          uw % n(c2) = uw % n(c1)
-          vw % n(c2) = vw % n(c1)
           if(turbulence_model .eq. REYNOLDS_STRESS) f22 % n(c2) = f22 % n(c1)
         end if
       end if


### PR DESCRIPTION
Dear guys,

Here is the fix - please check if other turbulent quantities have to be saved with RSM models.  Check lines 142 and 146 in Load_Backup.f90 and Save_Backup.f90 to see what I am talking about.