### PR TITLE
Missing heat fluxes

### DIFF
--- a/Sources/Process/Compute_Energy.f90
+++ b/Sources/Process/Compute_Energy.f90
@@ -253,24 +253,6 @@
              + phiy_f2 * grid % dy(s)      &
              + phiz_f2 * grid % dz(s) )
 
-    ! Turbulent heat fluxes according to GGDH scheme
-    ! (first line is GGDH, second line is SGDH substratced 
-    if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC .or.  &
-       turbulence_model .eq. RSM_MANCEAU_HANJALIC) then
-      ut_s =  (     grid % f(s)  * ut % n(c1)  &
-           +  (1. - grid % f(s)) * ut % n(c2))
-      vt_s =  (     grid % f(s)  * vt % n(c1)  &
-           +  (1. - grid % f(s)) * vt % n(c2))
-      wt_s =  (     grid % f(s)  * wt % n(c1)  &
-           +  (1. - grid % f(s)) * wt % n(c2))
-      t_stress = - (  ut_s * grid % sx(s)                    &
-                    + vt_s * grid % sy(s)                    &
-                    + wt_s * grid % sz(s) )                  &
-                    - (con_t * (  phix_f1 * grid % sx(s)     &
-                                + phiy_f1 * grid % sy(s)     &
-                                + phiz_f1 * grid % sz(s)) )
-    end if
-
     ! Cross diffusion part
     phi % c(c1) = phi % c(c1) + f_ex1 - f_im1
     if(c2 > 0) then
@@ -315,6 +297,43 @@
                           - phi % c(c) / (phi % n(c) + MICRO)
     end if
   end do
+
+  !---------------------------!
+  !                           !
+  !   Turbulent heat fluxes   !
+  !                           !
+  !---------------------------!
+  if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC .or.  &
+     turbulence_model .eq. RSM_MANCEAU_HANJALIC) then
+
+    do s = 1, grid % n_faces
+
+      c1 = grid % faces_c(1,s)
+      c2 = grid % faces_c(2,s)
+
+      ! Turbulent heat fluxes according to GGDH scheme
+      ! (first line is GGDH, second line is SGDH substratced 
+      ut_s =  (     grid % f(s)  * ut % n(c1)  &
+           +  (1. - grid % f(s)) * ut % n(c2))
+      vt_s =  (     grid % f(s)  * vt % n(c1)  &
+           +  (1. - grid % f(s)) * vt % n(c2))
+      wt_s =  (     grid % f(s)  * wt % n(c1)  &
+           +  (1. - grid % f(s)) * wt % n(c2))
+      t_stress = - (  ut_s * grid % sx(s)                    &
+                    + vt_s * grid % sy(s)                    &
+                    + wt_s * grid % sz(s) )                  &
+                    - (con_t * (  phix_f1 * grid % sx(s)     &
+                                + phiy_f1 * grid % sy(s)     &
+                                + phiz_f1 * grid % sz(s)) )
+
+      ! Put the influence of turbulent heat fluxes explicitly in the system
+      b(c1) = b(c1) + t_stress
+      if(c2 > 0) then
+        b(c2) = b(c2) - t_stress
+      end if
+
+    end do  ! through faces
+  end if  ! if models are of RSM type
 
   !--------------------!
   !                    !

--- a/Tests/Rans/Channel_Re_Tau_590/Rsm/control
+++ b/Tests/Rans/Channel_Re_Tau_590/Rsm/control
@@ -76,7 +76,7 @@
 #--------------------
 
  INITIAL_CONDITION
-  VARIABLES u     v   w   T    uu     vv     ww     uv    uw     vw    eps     f22 
+  VARIABLES u     v   w   t    uu     vv     ww     uv    uw     vw    eps     f22 
   VALUES    0.001 0.0 0.0 20.0 0.0001 0.0001 0.0001 0.00  0.0001 0.0   0.0002  0.1
 
 #---------------------
@@ -85,10 +85,10 @@
 
  BOUNDARY_CONDITION   top_wall
   TYPE    wall
-  VARIABLES u   v   w   T   uu    vv    ww    uv    uw    vw    eps   f22
+  VARIABLES u   v   w   t   uu    vv    ww    uv    uw    vw    eps   f22
   VALUES    0.0 0.0 0.0 22  0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
  BOUNDARY_CONDITION   bottom_wall
   TYPE    wall
-  VARIABLES u   v   w   T   uu    vv    ww    uv    uw    vw    eps   f22
+  VARIABLES u   v   w   t   uu    vv    ww    uv    uw    vw    eps   f22
   VALUES    0.0 0.0 0.0 22  0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0


### PR DESCRIPTION
I re-introduced turbulent heat fluxes which I previously removed believing they were part of cross diffusion treatment from old time steps :-(

Now there is a special section for them, starting with:
```
  !---------------------------!                                                 
  !                           !                                                 
  !   Turbulent heat fluxes   !                                                 
  !                           !                                                 
  !---------------------------!                                                 
  if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC .or.  &                        
     turbulence_model .eq. RSM_MANCEAU_HANJALIC) then                           

```

