### PR TITLE
Some changes related to Hanjalic Jakirlic RSM model

### DIFF
--- a/Sources/Process/Allocate_Variables.f90
+++ b/Sources/Process/Allocate_Variables.f90
@@ -284,10 +284,6 @@
 
     end if ! RSM_MANCEAU_HANJALIC
 
-    if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC) then
-      allocate(eps_tot(-grid % n_bnd_cells:grid % n_cells)); eps_tot = 0.
-    end if ! RSM_HANJALIC_JAKIRLIC
-
   end if ! RSM_MANCEAU_HANJALIC & RSM_HANJALIC_JAKIRLIC
 
   !----------------------!

--- a/Sources/Process/Main_Pro.f90
+++ b/Sources/Process/Main_Pro.f90
@@ -300,9 +300,7 @@
         ! Update the values at boundaries
         call Update_Boundary_Values(grid)
 
-        if(turbulence_model .eq. RSM_MANCEAU_HANJALIC) then
-          call Time_And_Length_Scale(grid)
-        end if
+        call Time_And_Length_Scale(grid)
 
         call Grad_Mod_For_Phi(grid, u % n, 1, u % x,.true.)    ! dU/dx
         call Grad_Mod_For_Phi(grid, u % n, 2, u % y,.true.)    ! dU/dy

--- a/Sources/Process/Read_Physical.f90
+++ b/Sources/Process/Read_Physical.f90
@@ -37,7 +37,7 @@
   end if
 
   if(turbulence_model .eq. RSM_MANCEAU_HANJALIC) then
-    call Constants_Reynolds_Stress()
+    call Constants_Manceau_Hanjalic()
   end if
 
   if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC) then

--- a/Sources/Process/Turbulence/Calculate_Heat_Flux.f90
+++ b/Sources/Process/Turbulence/Calculate_Heat_Flux.f90
@@ -45,17 +45,15 @@
   else if(turbulent_heat_flux_model .eq. GGDH) then
    
     do c = 1, grid % n_cells
-
-      ut % n(c) =  -0.22*t_scale(c) * (uu % n(c) * t_x(c) +  &
-                                       uv % n(c) * t_y(c) +  &
-                                       uw % n(c) * t_z(c))
-      vt % n(c) =  -0.22*t_scale(c) * (uv % n(c) * t_x(c) +  &
-                                       vv % n(c) * t_y(c) +  &
-                                       vw % n(c) * t_z(c))
-      wt % n(c) =  -0.22*t_scale(c) * (uw % n(c) * t_x(c) +  &
-                                       vw % n(c) * t_y(c) +  &
-                                       ww % n(c) * t_z(c))
-
+      ut % n(c) =  -c_theta*t_scale(c) * (uu % n(c) * t_x(c)  +  &
+                                          uv % n(c) * t_y(c)  +  &
+                                          uw % n(c) * t_z(c))
+      vt % n(c) =  -c_theta*t_scale(c) * (uv % n(c) * t_x(c)  +  &
+                                          vv % n(c) * t_y(c)  +  &
+                                          vw % n(c) * t_z(c))
+      wt % n(c) =  -c_theta*t_scale(c) * (uw % n(c) * t_x(c)  +  &
+                                          vw % n(c) * t_y(c)  +  &
+                                          ww % n(c) * t_z(c))
     end do
 
   else if(turbulent_heat_flux_model .eq. AFM) then

--- a/Sources/Process/Turbulence/Compute_Stresses.f90
+++ b/Sources/Process/Turbulence/Compute_Stresses.f90
@@ -374,7 +374,7 @@
 
     call Sources_Rsm_Manceau_Hanjalic(grid, phi % name)
   else if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC) then
-    call Sources_Rsm_Hanjalic_Jakirlic(grid, phi % name, n_time_step)
+    call Sources_Rsm_Hanjalic_Jakirlic(grid, phi % name)
   end if
 
   !---------------------------------!

--- a/Sources/Process/Turbulence/Constants_Hanjalic_Jakirlic.f90
+++ b/Sources/Process/Turbulence/Constants_Hanjalic_Jakirlic.f90
@@ -21,24 +21,16 @@
   c_mu_d  =  0.21
   c_mu25  = sqrt(sqrt(c_mu))
   c_mu75  = c_mu25**3
-  c_l     =  0.161
-  c_t     =  6.0
-  c_nu    = 80.0
-  g1      = 3.4
-  g1_star = 1.8
-  g2      = 4.2
-  g3      = 0.8
-  g3_star = 1.3
-  g4      = 1.25
-  g5      = 0.4
 
   kin % sigma = 1.0
-  eps % sigma = 1.0 !1.15
+  eps % sigma = 1.0 
   uu  % sigma = 1.0
   vv  % sigma = 1.0
   ww  % sigma = 1.0
   uv  % sigma = 1.0
   uw  % sigma = 1.0
   vw  % sigma = 1.0
+
+  c_theta = 0.25
 
   end subroutine

--- a/Sources/Process/Turbulence/Constants_Manceau_Hanjalic.f90
+++ b/Sources/Process/Turbulence/Constants_Manceau_Hanjalic.f90
@@ -1,0 +1,44 @@
+!==============================================================================!
+  subroutine Constants_Manceau_Hanjalic()
+!------------------------------------------------------------------------------!
+!   Initializes constants for Manceau Hanjalic Reynolds Stress turb. model     ! 
+!------------------------------------------------------------------------------!
+!----------------------------------[Modules]-----------------------------------!
+  use Rans_Mod
+  use Control_Mod
+!------------------------------------------------------------------------------!
+  implicit none
+!==============================================================================!
+
+  ! call Control_Mod_Turbulence_Model(.true.)
+  ! call Control_Mod_Turbulence_Model_Variant(.true.)
+
+  c_1e    =  1.44
+  c_2e    =  1.83
+  c_3e    =  0.55
+  c_mu    =  0.09
+  c_mu_d  =  0.21
+  c_mu25  = sqrt(sqrt(c_mu))
+  c_mu75  = c_mu25**3
+  c_l     =  0.161
+  c_t     =  6.0
+  c_nu    = 80.0
+  g1      =  3.4
+  g1_star =  1.8
+  g2      =  4.2
+  g3      =  0.8
+  g3_star =  1.3
+  g4      =  1.25
+  g5      =  0.4
+  c_theta =  0.22 
+
+  kin % sigma = 1.0
+  eps % sigma = 1.15
+  uu % sigma  = 1.0
+  vv % sigma  = 1.0
+  ww % sigma  = 1.0
+  uv % sigma  = 1.0
+  uw % sigma  = 1.0
+  vw % sigma  = 1.0
+
+  end subroutine

--- a/Sources/Process/Turbulence/Rans_Mod.f90
+++ b/Sources/Process/Turbulence/Rans_Mod.f90
@@ -22,13 +22,10 @@
  
   ! Constants for the k-eps-v2f model:
   real :: c_mu_d, c_l, c_t, alpha, c_nu, c_f1, c_f2
-  real :: g1, g1_star, g2, g3, g3_star, g4, g5 
+  real :: g1, g1_star, g2, g3, g3_star, g4, g5, c_theta 
 
   ! Constants for the Spalart-Allmaras model:
   real :: c_b1, c_b2, c_w1, c_w2, c_w3, c_v1
-
-  ! Total dissipation in 'HJ' model
-  real,allocatable :: eps_tot(:)
 
   ! Effective turbulent viscosity
   real, allocatable :: vis_t_eff(:)

--- a/Sources/Process/Turbulence/Time_And_Length_Scale.f90
+++ b/Sources/Process/Turbulence/Time_And_Length_Scale.f90
@@ -37,22 +37,20 @@
 
   kin_vis = viscosity / density
 
-  do c = 1, grid % n_cells
-    eps_l(c) = eps % n(c) + TINY  ! limited eps % n
- 
-    t1(c) = kin % n(c)/eps_l(c)
-    t2(c) = c_t*sqrt(kin_vis/eps_l(c))
-    t3(c) = 0.6/(sqrt(3.0)*c_mu_d * zeta % n(c) * shear(c) + TINY)
-
-    l1(c) = kin % n(c)**1.5/eps_l(c)
-    l2(c) = c_nu * (kin_vis**3 / eps_l(c))**0.25
-    l3(c) = sqrt(kin % n(c)/3.0)/(c_mu_d * zeta % n(c) * shear(c) + TINY)
-  end do
-
   if(turbulence_model .eq. K_EPS_ZETA_F .or.  &
      turbulence_model .eq. HYBRID_LES_RANS) then
 
-     do c = 1, grid % n_cells
+    do c = 1, grid % n_cells
+      eps_l(c) = max(eps % n(c),tiny) 
+ 
+      t1(c) = kin % n(c)/eps_l(c)
+      t2(c) = c_t*sqrt(kin_vis/eps_l(c))
+      t3(c) = 0.6/(sqrt(3.0)*c_mu_d * zeta % n(c) * shear(c) + TINY)
+
+      l1(c) = kin % n(c)**1.5/eps_l(c)
+      l2(c) = c_nu * (kin_vis**3 / eps_l(c))**0.25
+      l3(c) = sqrt(kin % n(c)/3.0)/(c_mu_d * zeta % n(c) * shear(c) + TINY)
+     
       t_scale(c) =       max( min(t1(c), t3(c)), t2(c) )
       l_scale(c) = c_l * max( min(l1(c), l3(c)), l2(c) )
     end do
@@ -60,9 +58,31 @@
   else if(turbulence_model .eq. RSM_MANCEAU_HANJALIC) then
 
     do c = 1, grid % n_cells
+      eps_l(c) = max(eps % n(c),tiny) 
       kin % n(c) = max(0.5*(uu % n(c) + vv % n(c) + ww % n(c)), TINY)
+ 
+      t1(c) = kin % n(c)/eps_l(c)
+      t2(c) = c_t*sqrt(kin_vis/eps_l(c))
+
+      l1(c) = kin % n(c)**1.5/eps_l(c)
+      l2(c) = c_nu * (kin_vis**3 / eps_l(c))**0.25
+
       t_scale(c) =       max( t1(c), t2(c) )
       l_scale(c) = c_l * max( l1(c), l2(c) )
+    end do
+
+  else if(turbulence_model .eq. RSM_HANJALIC_JAKIRLIC) then
+
+    do c = 1, grid % n_cells
+      eps_l(c) = max(eps % n(c),tiny) 
+      kin % n(c) = max(0.5*(uu % n(c) + vv % n(c) + ww % n(c)), TINY)
+ 
+      t1(c) = kin % n(c)/eps_l(c)
+
+      l1(c) = kin % n(c)**1.5/eps_l(c)
+
+      t_scale(c) = t1(c)
+      l_scale(c) = l1(c)
     end do
 
   end if

--- a/Sources/Process/makefile_explicit_dependencies
+++ b/Sources/Process/makefile_explicit_dependencies
@@ -1335,8 +1335,8 @@ $(DIR_SHARED)/Comm_Mod_Seq.f90 \
 $(DIR_SHARED)/Comm_Mod_Par.f90 \
 $(DIR_SHARED)/Comm_Mod/*/*.f90 
 
-#-- ./Turbulence/Constants_Reynolds_Stress.f90
-$(DIR_OBJECT)/Constants_Reynolds_Stress.o:\
+#-- ./Turbulence/Constants_Manceau_Hanjalic.f90
+$(DIR_OBJECT)/Constants_Manceau_Hanjalic.o:\
 $(DIR_OBJECT)/Rans_Mod.o \
 $(DIR_OBJECT)/Control_Mod.o \
 Control_Mod/*/*.f90 


### PR DESCRIPTION
I made changes in Hanjalic Jakirlic model based on an experience gained during computation of flow around cylinder with heat transfer. It proved that Eps_tot is making a lot of problems and does not influence results much. It is deleted and only Eps is used.
c_theta in GGDH is introduced and defined in Constants_Hanjalic_Jakirlic and Constants_Manceau_Hanjalic.
Constants_Reynolds_Stress is renamed to Constants_Manceau_Hanjalic.
I suggest to implement these changes before the pull planned for buoyancy model.