### PR TITLE
statistics in RSM models causes a crash

### DIFF
--- a/Sources/Process/Turbulence/Allocate.f90
+++ b/Sources/Process/Turbulence/Allocate.f90
@@ -228,6 +228,13 @@
 
     if(turbulence_statistics) then
 
+      ! First moments
+      call Var_Mod_Allocate_Statistics(u)
+      call Var_Mod_Allocate_Statistics(v)
+      call Var_Mod_Allocate_Statistics(w)
+      call Var_Mod_Allocate_Statistics(p)
+
+      ! Second moments
       call Var_Mod_Allocate_Statistics(uu)
       call Var_Mod_Allocate_Statistics(vv)
       call Var_Mod_Allocate_Statistics(ww)


### PR DESCRIPTION
[Process/Turbulence/Allocate.f90](https://github.com/DelNov/T-Flows/blob/93b9f061b5ec14c3e96bba6a3de5d99d34c31f0e/Sources/Process/Turbulence/Allocate.f90#L231) function did not have an allocation block for the first moments statistics (**u % mean**, **v % mean**,**w % mean**, **p % mean**) for RSM models.