### PR TITLE
Some improvements for rough walls model and one bug corrected

### DIFF
--- a/Sources/Process/Turbulence/Calculate_Vis_T_K_Eps.f90
+++ b/Sources/Process/Turbulence/Calculate_Vis_T_K_Eps.f90
@@ -126,12 +126,12 @@
 
         if(rough_walls) then
           z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)  
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o)
           y_plus(c1) = Y_Plus_Rough_Walls(u_tau(c1),             &
                                           grid % wall_dist(c1),  &
                                           kin_vis)
           u_plus     = U_Plus_Rough_Walls(grid % wall_dist(c1))
-          vis_wall(c1) = y_plus(c1) * viscosity * kappa  &
-                       / log((grid % wall_dist(c1)+z_o)/z_o)  ! is this U+?
+          vis_wall(c1) = y_plus(c1) * viscosity / u_plus
         end if
 
         if(heat_transfer) then

--- a/Sources/Process/Turbulence/Calculate_Vis_T_K_Eps_Zeta_F.f90
+++ b/Sources/Process/Turbulence/Calculate_Vis_T_K_Eps_Zeta_F.f90
@@ -119,12 +119,12 @@
 
         if(rough_walls) then
           z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)      
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o) 
           y_plus(c1) = Y_Plus_Rough_Walls(u_tau(c1),             &
                                           grid % wall_dist(c1),  &
                                           kin_vis)
           u_plus     = U_Plus_Rough_Walls(grid % wall_dist(c1))
-          vis_wall(c1) = y_plus(c1) * viscosity * kappa  &
-                       / log((grid % wall_dist(c1)+z_o)/z_o)  ! is this U+?
+          vis_wall(c1) = y_plus(c1) * viscosity / u_plus
         end if  
 
         if(heat_transfer) then

--- a/Sources/Process/Turbulence/Source_Eps_K_Eps.f90
+++ b/Sources/Process/Turbulence/Source_Eps_K_Eps.f90
@@ -35,7 +35,7 @@
   integer                    :: s, c, c1, c2, j
   real                       :: u_tan, u_nor_sq, u_nor, u_tot_sq
   real                       :: re_t, f_mu, u_tau_new, fa, kin_vis
-  real                       :: eps_wf, eps_int, ebf, y_star
+  real                       :: eps_wf, eps_int, y_star
 !==============================================================================!
 !   Dimensions:                                                                !
 !                                                                              !
@@ -116,7 +116,8 @@
         end if
  
         if(rough_walls) then 
-          z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)       
+          z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)     
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o)  
           eps % n(c1) = c_mu75 * kin % n(c1)**1.5  &
                       / ((grid % wall_dist(c1) + z_o) * kappa)
 
@@ -136,7 +137,6 @@
 
           u_tau_new = sqrt(tau_wall(c1)/density)
           y_plus(c1) = Y_Plus_Low_Re(u_tau_new, grid % wall_dist(c1), kin_vis)
-          ebf = 0.01 * y_plus(c1)**4 / (1.0 + 5.0*y_plus(c1))
 
           eps_int = 2.0*viscosity/density * kin % n(c1)    &
                   / grid % wall_dist(c1)**2

--- a/Sources/Process/Turbulence/Source_Eps_K_Eps_Zeta_F.f90
+++ b/Sources/Process/Turbulence/Source_Eps_K_Eps_Zeta_F.f90
@@ -27,7 +27,7 @@
   real,              pointer :: b(:)
   integer                    :: c, s, c1, c2, j
   real                       :: u_tan, u_nor_sq, u_nor, u_tot_sq
-  real                       :: e_sor, c_11e, ebf
+  real                       :: e_sor, c_11e
   real                       :: eps_wf, eps_int
   real                       :: fa, u_tau_new, kin_vis
 !==============================================================================!
@@ -115,6 +115,7 @@
 
         if(rough_walls) then 
           z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)      
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o)
           eps % n(c1) = c_mu75 * kin % n(c1)**1.5 / & 
                       ((grid % wall_dist(c1) + z_o) * kappa)
 
@@ -135,8 +136,6 @@
           u_tau_new = sqrt(tau_wall(c1)/density)
           y_plus(c1) = Y_Plus_Low_Re(u_tau_new, grid % wall_dist(c1), kin_vis)
 
-          ebf = 0.001 * y_plus(c1)**4 / (1.0 + y_plus(c1))
-
           eps_int = 2.0* kin_vis * kin % n(c1)  &
                   / grid % wall_dist(c1)**2
           eps_wf  = c_mu75 * kin % n(c1)**1.5            &
@@ -148,7 +147,6 @@
                      / (kappa*grid % wall_dist(c1) * p_kin(c1)),  &
                      1.0)
             eps % n(c1) = (1.0 - fa) * eps_int + fa * eps_wf
-
             ! Adjusting coefficient to fix eps value in near wall calls
             do j = a % row(c1), a % row(c1 + 1) - 1
               a % val(j) = 0.0

--- a/Sources/Process/Turbulence/Source_Kin_K_Eps.f90
+++ b/Sources/Process/Turbulence/Source_Kin_K_Eps.f90
@@ -107,6 +107,7 @@
 
         if(rough_walls) then
           z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)      
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o)
           u_tau(c1) = c_mu25 * sqrt(kin % n(c1))
           y_plus(c1) = u_tau(c1) * (grid % wall_dist(c1) + z_o) &
                      / kin_vis
@@ -116,7 +117,7 @@
 
           p_kin(c1) = density * tau_wall(c1) * c_mu25 * sqrt(kin % n(c1))   &
                     / (kappa*(grid % wall_dist(c1) + z_o))
-          b(c1)     = b(c1) + (p_kin(c1) - p_kin(c1))   &
+          b(c1)     = b(c1) + (p_kin(c1) - vis_t(c1) * shear(c1)**2)   &
                     * grid % vol(c1)
         else
           u_tau(c1) = c_mu25 * sqrt(kin % n(c1))
@@ -127,7 +128,7 @@
 
           ebf = 0.01 * y_plus(c1)**4 / (1.0 + 5.0*y_plus(c1))
 
-          p_kin_wf  = tau_wall(c1) * 0.07**0.25 * sqrt(kin % n(c1))  &
+          p_kin_wf  = tau_wall(c1) * c_mu25 * sqrt(kin % n(c1))  &
                     / (grid % wall_dist(c1) * kappa)
 
           p_kin_int = vis_t(c1) * shear(c1)**2

--- a/Sources/Process/Turbulence/Source_Kin_K_Eps_Zeta_F.f90
+++ b/Sources/Process/Turbulence/Source_Kin_K_Eps_Zeta_F.f90
@@ -132,7 +132,8 @@
         end if
 
         if(rough_walls) then
-          z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)       
+          z_o = Roughness_Coefficient(grid, z_o_f(c1), c1)    
+          z_o = max(grid % wall_dist(c1)/(e_log*y_plus(c1)),z_o) 
           u_tau(c1)  = c_mu25 * sqrt(kin % n(c1))
           y_plus(c1) = Y_Plus_Rough_Walls(u_tau(c1), &
                        grid % wall_dist(c1), kin_vis) 
@@ -153,7 +154,7 @@
 
           ebf = max(0.01 * y_plus(c1)**4 / (1.0 + 5.0*y_plus(c1)),tiny)
 
-          p_kin_wf  = tau_wall(c1) * 0.07**0.25 * sqrt(kin % n(c1))  &
+          p_kin_wf  = tau_wall(c1) * c_mu25 * sqrt(kin % n(c1))  &
                     / (grid % wall_dist(c1) * kappa)
 
           p_kin_int = vis_t(c1) * shear(c1)**2

--- a/Sources/Process/Turbulence/Time_And_Length_Scale.f90
+++ b/Sources/Process/Turbulence/Time_And_Length_Scale.f90
@@ -45,7 +45,7 @@
 
       t_1(c) = kin % n(c)/eps_l(c)
       t_2(c) = c_t*sqrt(kin_vis/eps_l(c))
-      t_3(c) = 0.6/(sqrt(3.0)*c_mu_d * zeta % n(c) * shear(c) + TINY)
+      t_3(c) = 0.8/(sqrt(3.0)*c_mu_d * zeta % n(c) * shear(c) + TINY)
 
       l_1(c) = kin % n(c)**1.5/eps_l(c)
       l_2(c) = c_nu * (kin_vis**3 / eps_l(c))**0.25


### PR DESCRIPTION
I defined a limiter for hydraulic roughness z_o so if z_o is very small or close to zero, the standard log law for smooth wall will be imposed. 
There was one bug discovered by Massimo in Kin source for k-eps model. It is corrected. 