### PR TITLE
Bug in Save_Vtu_Results.f90

### DIFF
--- a/Sources/Process/Load_Physical_Properties.f90
+++ b/Sources/Process/Load_Physical_Properties.f90
@@ -19,5 +19,6 @@
   call Control_Mod_Mass_Density         (density)
   call Control_Mod_Thermal_Conductivity (conductivity)
   call Control_Mod_Roughness_Coefficient(z_o)
+  call Control_Mod_Thermal_Expansion_Coefficient (beta_tec)
 
   end subroutine

--- a/Sources/Process/Save_Vtu_Results.f90
+++ b/Sources/Process/Save_Vtu_Results.f90
@@ -337,9 +337,9 @@
       end do
       call Save_Vtu_Scalar(grid, IN_4, IN_5, "TemperatureFluctuations",  &
                                  tt_mean(1))
-      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxX", ut_mean(1))
-      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxY", vt_mean(1))
-      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxZ", wt_mean(1))
+      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbHeatFluxX_resolved", ut_mean(1))
+      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbHeatFluxY_resolved", vt_mean(1))
+      call Save_Vtu_Scalar(grid, IN_4, IN_5, "TurbHeatFluxZ_resolved", wt_mean(1))
     end if
 
     if(flow % n_scalars > 0) then


### PR DESCRIPTION
There was a bug in Save_Vtu_Results.f90 which in case of hybrid model writes name of variable TurbulentHeatFluxX twice in the file which then causes crashing of Paraview. It is fixed now.

