### PR TITLE
Eliminated redundant array "buf_pos" from Div_Mod.

### DIFF
--- a/Sources/Divide/Allocate_Additional.f90
+++ b/Sources/Divide/Allocate_Additional.f90
@@ -4,7 +4,7 @@
 !   Allocates additional memory for Divisor                                    !
 !------------------------------------------------------------------------------!
 !----------------------------------[Modules]-----------------------------------!
-  use Div_Mod,  only: buf_send_ind, buf_recv_ind, buf_pos
+  use Div_Mod
   use Grid_Mod, only: Grid_Type,  &
                       Grid_Mod_Allocate_New_Numbers
 !------------------------------------------------------------------------------!
@@ -23,6 +23,5 @@
   ! Variables declared in Div_Mod
   allocate (buf_send_ind(grid % n_faces));  buf_send_ind = 0
   allocate (buf_recv_ind(grid % n_faces));  buf_recv_ind = 0
-  allocate (buf_pos     (grid % n_faces));  buf_pos      = 0
 
   end subroutine

--- a/Sources/Divide/Create_Buffers_And_Save.f90
+++ b/Sources/Divide/Create_Buffers_And_Save.f90
@@ -23,9 +23,7 @@
                           nc_sub,    &  ! number of cells in the subdomain
                           nf_sub,    &  ! number of faces in the subdomain
                           nbc_sub,   &  ! number of boundary cells in sub.
-                          ncc_sub,   &  ! number of copy cells in the sub.
-                          nbf_sub,   &  ! number of buffer cells in subdom.
-                          nbfcc_sub     ! number of buffer copy cells in sub.
+                          nbf_sub
   character(len=80)    :: name_buf
   integer, allocatable :: side_cell(:,:)
   logical, parameter   :: verbose = .false.
@@ -82,7 +80,6 @@
     ! Faces & real boundary cells
     nf_sub  = 0  ! number of faces in subdomain
     nbc_sub = 0  ! number of real boundary cells in subdomain
-    ncc_sub = 0
     do s = 1, grid % n_faces
       grid % new_f(s) = 0
     end do
@@ -122,7 +119,6 @@
     !   Create buffers   !
     !--------------------!
     nbf_sub   = 0
-    nbfcc_sub = 0
 
     if(verbose) then
       write(fu,'(a30)') '# Number of physical cells:'
@@ -217,7 +213,6 @@
     print '(a,i9,a)', ' # ', nn_sub,            ' nodes' 
     print '(a,i9,a)', ' # ', nf_sub + nbf_sub,  ' faces' 
     print '(a,i9,a)', ' # ', nbc_sub,           ' boundary cells' 
-    print '(a,i9,a)', ' # ', ncc_sub,           ' copy cell pairs'
     print '(a,i5,a)', ' #---------------------------------------------'
 
     call Grid_Mod_Save_Cns(grid,         &

--- a/Sources/Divide/Create_Buffers_And_Save.f90
+++ b/Sources/Divide/Create_Buffers_And_Save.f90
@@ -143,7 +143,6 @@
               nbf_sub = nbf_sub + 1                ! increase buffer cell count
               buf_send_ind(nbf_sub) = grid % new_c(c1)  ! buffer send index
               buf_recv_ind(nbf_sub) = c2           ! important for coordinate
-              buf_pos(nbf_sub) = nc_sub + nbf_sub  ! place buffers after cells
 
               grid % new_f(s) = nf_sub + nbf_sub
             end if
@@ -152,7 +151,6 @@
               nbf_sub = nbf_sub + 1                ! increasu buffer cell count
               buf_send_ind(nbf_sub) = grid % new_c(c2)  ! buffer send index
               buf_recv_ind(nbf_sub) = c1           ! important for coordinate
-              buf_pos(nbf_sub) = nc_sub + nbf_sub  ! place buffers after cells
 
               grid % new_f(s) = nf_sub + nbf_sub
             end if

--- a/Sources/Divide/Create_Buffers_And_Save.f90
+++ b/Sources/Divide/Create_Buffers_And_Save.f90
@@ -23,7 +23,8 @@
                           nc_sub,    &  ! number of cells in the subdomain
                           nf_sub,    &  ! number of faces in the subdomain
                           nbc_sub,   &  ! number of boundary cells in sub.
-                          nbf_sub
+                          nbf_sub,   &
+                          nbfc_sub
   character(len=80)    :: name_buf
   integer, allocatable :: side_cell(:,:)
   logical, parameter   :: verbose = .false.
@@ -118,7 +119,8 @@
     !--------------------!
     !   Create buffers   !
     !--------------------!
-    nbf_sub   = 0
+    nbf_sub  = 0
+    nbfc_sub = 0
 
     if(verbose) then
       write(fu,'(a30)') '# Number of physical cells:'
@@ -140,6 +142,11 @@
               buf_send_ind(nbf_sub) = grid % new_c(c1)  ! buffer send index
               buf_recv_ind(nbf_sub) = c2           ! important for coordinate
 
+              if(grid % new_c(c2) .eq. 0) then
+                nbfc_sub = nbfc_sub + 1
+                grid % new_c(c2) = nbfc_sub
+              end if
+
               grid % new_f(s) = nf_sub + nbf_sub
             end if
             if( (grid % comm % cell_proc(c2) .eq. sub) .and.  &
@@ -147,6 +154,11 @@
               nbf_sub = nbf_sub + 1                ! increasu buffer cell count
               buf_send_ind(nbf_sub) = grid % new_c(c2)  ! buffer send index
               buf_recv_ind(nbf_sub) = c1           ! important for coordinate
+
+              if(grid % new_c(c1) .eq. 0) then
+                nbfc_sub = nbfc_sub + 1
+                grid % new_c(c1) = nbfc_sub
+              end if
 
               grid % new_f(s) = nf_sub + nbf_sub
             end if
@@ -231,7 +243,7 @@
     call Save_Vtu_Cells(grid,       &
                         sub,        &
                         nn_sub,     &
-                        nc_sub)
+                        nc_sub + nbfc_sub)
 
     call Save_Vtu_Links(grid,       &
                         sub,        &

--- a/Sources/Divide/Main_Div.f90
+++ b/Sources/Divide/Main_Div.f90
@@ -31,7 +31,7 @@
   call Grid_Mod_Load_Geo  (grid, 0)
 
   ! Initialize processor numbers (poor idea to put it here)
-  grid % comm % cell_proc(1:grid % n_cells) = 1
+  grid % comm % cell_proc(-grid % n_bnd_cells:grid % n_cells) = 1
 
   print *, '# Number of subdomains:'
   read(*,*)  n_sub

--- a/Sources/Shared/Div_Mod.f90
+++ b/Sources/Shared/Div_Mod.f90
@@ -9,6 +9,6 @@
 
   ! Buffer send index and buffer receive index.  
   ! Used for plotting dcomposed grids with links.
-  integer, allocatable :: buf_send_ind(:), buf_recv_ind(:), buf_pos(:)
+  integer, allocatable :: buf_send_ind(:), buf_recv_ind(:)
 
   end module

--- a/Sources/Shared/Grid_Mod/Decompose.f90
+++ b/Sources/Shared/Grid_Mod/Decompose.f90
@@ -133,4 +133,12 @@
     grid % comm % cell_proc(c) = part(c)
   end do
 
+  do s = 1, grid % n_faces
+    c1 = grid % faces_c(1, s)
+    c2 = grid % faces_c(2, s)
+    if(c2 < 0) then
+      grid % comm % cell_proc(c2) = grid % comm % cell_proc(c1)
+    end if
+  end do
+
   end subroutine

--- a/Sources/Shared/Grid_Mod/Save_Cns.f90
+++ b/Sources/Shared/Grid_Mod/Save_Cns.f90
@@ -121,12 +121,10 @@
     end if
   end do
 
-  ! nbf_sub buffer faces (copy faces here, avoid them with buf_pos)
+  ! nbf_sub buffer faces and the new numbers of cells surrounding them
   do s = 1, nbf_sub
-    if(buf_pos(s) > nc_sub) then     ! normal buffer (non-copy)
-      write(fu) buf_send_ind(s),  &  ! new cell number
-               buf_pos(s)            ! position in the buffer
-    end if
+    write(fu) buf_send_ind(s),  &
+              nc_sub + s
   end do
 
   !--------------!

--- a/Sources/Shared/Grid_Mod/Save_Cns.f90
+++ b/Sources/Shared/Grid_Mod/Save_Cns.f90
@@ -56,7 +56,7 @@
 
   ! Number of nodes for each cell
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % cells_n_nodes(c)
     end if
   end do
@@ -66,7 +66,7 @@
 
   ! Cells' nodes
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       do n = 1, grid % cells_n_nodes(c)
         write(fu) grid % new_n(grid % cells_n(n,c))
       end do
@@ -80,7 +80,7 @@
 
   ! Cells' processor ids
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % comm % cell_proc(c)
     end if
   end do
@@ -88,7 +88,7 @@
     write(fu) grid % comm % cell_proc(buf_recv_ind(s))
   end do
   do c = -1, -grid % n_bnd_cells, -1
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % comm % cell_proc(c)
     end if
   end do
@@ -133,7 +133,7 @@
 
   ! Physical boundary cells
   do c = -1, -grid % n_bnd_cells, -1
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % bnd_cond % color(c)
     end if
   end do

--- a/Sources/Shared/Grid_Mod/Save_Geo.f90
+++ b/Sources/Shared/Grid_Mod/Save_Geo.f90
@@ -41,7 +41,7 @@
   !-----------------------------!
   do var = 1, 3
     do c = 1, grid % n_cells
-      if(grid % new_c(c) > 0) then
+      if(grid % comm % cell_proc(c) .eq. sub) then
         if(var .eq. 1) write(fu) grid % xc(c)
         if(var .eq. 2) write(fu) grid % yc(c)
         if(var .eq. 3) write(fu) grid % zc(c)
@@ -71,7 +71,7 @@
   !   Cell volumes   !
   !------------------!
   do c = 1, grid % n_cells
-    if(grid % new_c(c) > 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % vol(c)
     end if
   end do
@@ -83,7 +83,7 @@
   !   Wall distance   !
   !-------------------!
   do c = 1, grid % n_cells
-    if(grid % new_c(c) > 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % wall_dist(c)
     end if
   end do
@@ -91,7 +91,7 @@
     write(fu) grid % wall_dist(buf_recv_ind(s))
   end do
   do c = -1, -grid % n_bnd_cells, -1
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu) grid % wall_dist(c)
     end if
   end do

--- a/Sources/Shared/Save_Grid_Mod/Vtu/Save_Vtu_Links.f90
+++ b/Sources/Shared/Save_Grid_Mod/Vtu/Save_Vtu_Links.f90
@@ -69,12 +69,14 @@
                    IN_5, grid % xn(n), grid % yn(n), grid % zn(n)
   end do
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) write(fu, '(a,1pe15.7,1pe15.7,1pe15.7)')   &
-                   IN_5, grid % xc(c), grid % yc(c), grid % zc(c)
+    if(grid % comm % cell_proc(c) .eq. sub)      &
+      write(fu, '(a,1pe15.7,1pe15.7,1pe15.7)')   &
+                 IN_5, grid % xc(c), grid % yc(c), grid % zc(c)
   end do
   do c = -1,-grid % n_bnd_cells,-1
-    if(grid % new_c(c) .ne. 0) write(fu, '(a,1pe15.7,1pe15.7,1pe15.7)')   &
-                   IN_5, grid % xc(c), grid % yc(c), grid % zc(c)
+    if(grid % comm % cell_proc(c) .eq. sub)      &
+      write(fu, '(a,1pe15.7,1pe15.7,1pe15.7)')   &
+                 IN_5, grid % xc(c), grid % yc(c), grid % zc(c)
   end do
   do c = 1,n_buf_cells_sub
     write(fu, '(a,1pe15.7,1pe15.7,1pe15.7)') IN_5,  &
@@ -95,7 +97,7 @@
                           ' format="ascii">'
 
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
 
       ! Hexahedral
       if(grid % cells_n_nodes(c) .eq. 8) then
@@ -222,7 +224,7 @@
                           'format="ascii">'
   offset = 0
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       offset = offset + grid % cells_n_nodes(c)
       write(fu,'(a,i9)') IN_5, offset
     end if
@@ -245,7 +247,7 @@
   ! Now write all cells' types
   write(fu,'(a,a)') IN_4, '<DataArray type="Int64" Name="types" format="ascii">'
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       if(grid % cells_n_nodes(c) .eq. 4) write(fu,'(a,i9)') IN_5, VTK_TETRA
       if(grid % cells_n_nodes(c) .eq. 8) write(fu,'(a,i9)') IN_5, VTK_HEXAHEDRON
       if(grid % cells_n_nodes(c) .eq. 6) write(fu,'(a,i9)') IN_5, VTK_WEDGE
@@ -271,7 +273,7 @@
   write(fu,'(a,a)') IN_4, '<DataArray type="Int64" ' // & 
                           'Name="link type" format="ascii">'
   do c = 1, grid % n_cells
-    if(grid % new_c(c) .ne. 0) then
+    if(grid % comm % cell_proc(c) .eq. sub) then
       write(fu,'(a,i9)') IN_5, 0
     end if
   end do


### PR DESCRIPTION
Dear Egor,

Div_Mod is an artifact of the past - of the days when T-Flows was still called T-Rex, was written in Fortran 77 and used modules to store global variables :-(

Hence, I am looking for a way to eliminate Div_Mod, variable by variable.  With this pull request I am eliminating one of them - buf_pos.

    Cheers,

    Bojan