### PR TITLE
Update ggdh

### DIFF
--- a/Sources/Process/Save_Results_Mod/Vtu/Save_Results.f90
+++ b/Sources/Process/Save_Results_Mod/Vtu/Save_Results.f90
@@ -448,6 +448,17 @@
     call Save_Scalar(grid, IN_4, IN_5, "ReynoldsStressYZ", plot_inside,     &
                                        turb % vw % n(-grid % n_bnd_cells),  &
                                        f8, f9)
+    if(heat_transfer) then
+      call Save_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxX", plot_inside,    &
+                                         turb % ut % n(-grid % n_bnd_cells),   &
+                                         f8, f9)
+      call Save_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxY", plot_inside,    &
+                                         turb % vt % n(-grid % n_bnd_cells),   &
+                                         f8, f9)
+      call Save_Scalar(grid, IN_4, IN_5, "TurbulentHeatFluxZ", plot_inside,    &
+                                         turb % wt % n(-grid % n_bnd_cells),   &
+                                         f8, f9)
+    end if
   end if
 
   ! Statistics for large-scale simulations of turbulence

--- a/Sources/Process/Turb_Mod.f90
+++ b/Sources/Process/Turb_Mod.f90
@@ -208,6 +208,7 @@
   include 'Turb_Mod/Calculate_Face_Vis.f90'
   include 'Turb_Mod/Calculate_Heat_Flux.f90'
   include 'Turb_Mod/Calculate_Mean.f90'
+  include 'Turb_Mod/Calculate_Stress.f90'
   include 'Turb_Mod/Substract_Face_Stress.f90'
 
   ! Functions to set turbulence constants

--- a/Sources/Process/Turb_Mod/Allocate.f90
+++ b/Sources/Process/Turb_Mod/Allocate.f90
@@ -51,6 +51,16 @@
       call Var_Mod_Allocate_New_Only(turb % wt, grid, 'WT')
       allocate(turb % con_w(-nb:nc));  turb % con_w = 0.  ! wall cond
       allocate(turb % p_t2 (-nb:nc));  turb % p_t2  = 0.
+
+      if(turbulent_heat_flux_model .eq. GGDH) then
+        ! Reynolds stresses
+        call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
+        call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
+        call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
+        call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
+        call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
+        call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
+      end if
     end if ! heat_transfer
 
     ! Turbulent statistics; if needed
@@ -122,6 +132,16 @@
       call Var_Mod_Allocate_New_Only(turb % wt, grid, 'WT')
       allocate(turb % con_w(-nb:nc));  turb % con_w = 0.  ! wall cond
       allocate(turb % p_t2 (-nb:nc));  turb % p_t2  = 0.
+
+      if(turbulent_heat_flux_model .eq. GGDH) then
+        ! Reynolds stresses
+        call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
+        call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
+        call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
+        call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
+        call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
+        call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
+      end if
     end if ! heat_transfer
 
     if(turbulence_statistics) then

--- a/Sources/Process/Turb_Mod/Allocate.f90
+++ b/Sources/Process/Turb_Mod/Allocate.f90
@@ -52,15 +52,13 @@
       allocate(turb % con_w(-nb:nc));  turb % con_w = 0.  ! wall cond
       allocate(turb % p_t2 (-nb:nc));  turb % p_t2  = 0.
 
-      if(turbulent_heat_flux_model .eq. GGDH) then
-        ! Reynolds stresses
-        call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
-        call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
-        call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
-        call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
-        call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
-        call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
-      end if
+      ! Reynolds stresses
+      call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
+      call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
+      call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
+      call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
+      call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
+      call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
     end if ! heat_transfer
 
     ! Turbulent statistics; if needed
@@ -133,15 +131,13 @@
       allocate(turb % con_w(-nb:nc));  turb % con_w = 0.  ! wall cond
       allocate(turb % p_t2 (-nb:nc));  turb % p_t2  = 0.
 
-      if(turbulent_heat_flux_model .eq. GGDH) then
-        ! Reynolds stresses
-        call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
-        call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
-        call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
-        call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
-        call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
-        call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
-      end if
+      ! Reynolds stresses
+      call Var_Mod_Allocate_New_Only(turb % uu, grid, 'UU')
+      call Var_Mod_Allocate_New_Only(turb % vv, grid, 'VV')
+      call Var_Mod_Allocate_New_Only(turb % ww, grid, 'WW')
+      call Var_Mod_Allocate_New_Only(turb % uv, grid, 'UV')
+      call Var_Mod_Allocate_New_Only(turb % uw, grid, 'UW')
+      call Var_Mod_Allocate_New_Only(turb % vw, grid, 'VW')
     end if ! heat_transfer
 
     if(turbulence_statistics) then

--- a/Sources/Process/Turb_Mod/Calculate_Stress.f90
+++ b/Sources/Process/Turb_Mod/Calculate_Stress.f90
@@ -1,0 +1,41 @@
+!==============================================================================!
+  subroutine Turb_Mod_Calculate_Stress(turb)
+!------------------------------------------------------------------------------!
+!   Calculates algebraic Reynolds stresses                                     !
+!------------------------------------------------------------------------------!
+  implicit none
+!---------------------------------[Arguments]----------------------------------!
+  type(Turb_Type),  target :: turb
+!-----------------------------------[Locals]-----------------------------------!
+  type(Field_Type), pointer :: flow
+  type(Grid_Type),  pointer :: grid
+  type(Var_Type),   pointer :: u, v, w
+  type(Var_Type),   pointer :: uu, vv, ww, uv, uw, vw
+  type(Var_Type),   pointer :: kin, eps
+  integer                   :: c
+!==============================================================================!
+
+  ! Take aliases
+  flow => turb % pnt_flow
+  grid => flow % pnt_grid
+  call Field_Mod_Alias_Momentum(flow, u, v, w)
+  call Turb_Mod_Alias_Stresses (turb, uu, vv, ww, uv, uw, vw)
+  call Turb_Mod_Alias_K_Eps    (turb, kin, eps)
+
+  call Field_Mod_Grad_Variable(flow, u)
+  call Field_Mod_Grad_Variable(flow, v)
+  call Field_Mod_Grad_Variable(flow, w)
+
+  do c = 1, grid % n_cells
+
+    uu % n(c) = - 2. * turb % vis_t(c) * u % x(c) + TWO_THIRDS * kin % n(c)
+    vv % n(c) = - 2. * turb % vis_t(c) * v % y(c) + TWO_THIRDS * kin % n(c)
+    ww % n(c) = - 2. * turb % vis_t(c) * w % z(c) + TWO_THIRDS * kin % n(c)
+
+    uv % n(c) = - turb % vis_t(c) * (u % y(c) + v % x(c))
+    uw % n(c) = - turb % vis_t(c) * (u % z(c) + w % x(c))
+    vw % n(c) = - turb % vis_t(c) * (v % z(c) + w % y(c))
+
+  end do
+
+  end subroutine

--- a/Sources/Process/Turb_Mod/Const_Hanjalic_Jakirlic.f90
+++ b/Sources/Process/Turb_Mod/Const_Hanjalic_Jakirlic.f90
@@ -16,16 +16,15 @@
   c_mu_d  =  0.21
   c_mu25  = sqrt(sqrt(c_mu))
   c_mu75  = c_mu25**3
+  c_theta = 0.25
 
   turb % kin % sigma = 1.0
-  turb % eps % sigma = 1.0 
+  turb % eps % sigma = 1.0
   turb % uu  % sigma = 1.0
   turb % vv  % sigma = 1.0
   turb % ww  % sigma = 1.0
   turb % uv  % sigma = 1.0
   turb % uw  % sigma = 1.0
   turb % vw  % sigma = 1.0
-
-  c_theta = 0.25
 
   end subroutine

--- a/Sources/Process/Turb_Mod/Const_K_Eps.f90
+++ b/Sources/Process/Turb_Mod/Const_K_Eps.f90
@@ -8,13 +8,14 @@
   type(Turb_Type),  target :: turb
 !==============================================================================!
 
-  c_1e   = 1.5
-  c_2e   = 1.9
-  c_mu   = 0.09
-  c_mu25 = sqrt(sqrt(c_mu))
-  c_mu75 = c_mu25**3
-  kappa  = 0.41
-  e_log  = 8.342
+  c_1e    = 1.5
+  c_2e    = 1.9
+  c_mu    = 0.09
+  c_mu25  = sqrt(sqrt(c_mu))
+  c_mu75  = c_mu25**3
+  kappa   = 0.41
+  e_log   = 8.342
+  c_theta = 0.2
 
   turb % kin % sigma = 1.4
   turb % eps % sigma = 1.4

--- a/Sources/Process/Turb_Mod/Const_K_Eps_Zeta_F.f90
+++ b/Sources/Process/Turb_Mod/Const_K_Eps_Zeta_F.f90
@@ -9,20 +9,21 @@
   type(Turb_Type), target :: turb
 !==============================================================================!
 
-  c_1e   =  1.4
-  c_2e   =  1.9
-  c_mu   =  0.09
-  c_mu_d =  0.22
-  c_mu25 = sqrt(sqrt(c_mu))
-  c_mu75 = c_mu25**3
-  kappa  =  0.41
-  e_log  =  8.342
-  c_l    =  0.36
-  c_t    =  6.0
-  c_nu   = 85.0
-  alpha  =  0.012
-  c_f1   =  1.4
-  c_f2   =  0.3
+  c_1e    =  1.4
+  c_2e    =  1.9
+  c_mu    =  0.09
+  c_mu_d  =  0.22
+  c_mu25  = sqrt(sqrt(c_mu))
+  c_mu75  = c_mu25**3
+  kappa   =  0.41
+  e_log   =  8.342
+  c_l     =  0.36
+  c_t     =  6.0
+  c_nu    = 85.0
+  alpha   =  0.012
+  c_f1    =  1.4
+  c_f2    =  0.3
+  c_theta =  0.2
 
   ! Constants for buoyancy wall function
   c_mu_theta   =  0.1225

--- a/Sources/Process/Turb_Mod/Const_Manceau_Hanjalic.f90
+++ b/Sources/Process/Turb_Mod/Const_Manceau_Hanjalic.f90
@@ -25,7 +25,7 @@
   g3_star =  1.3
   g4      =  1.25
   g5      =  0.4
-  c_theta =  0.22 
+  c_theta =  0.22
 
   turb % kin % sigma = 1.0
   turb % eps % sigma = 1.15

--- a/Sources/Process/Turb_Mod/Main.f90
+++ b/Sources/Process/Turb_Mod/Main.f90
@@ -33,6 +33,7 @@
     call Turb_Mod_Compute_Variable(turb, sol, ini, turb % eps, n)
 
     if(heat_transfer) then
+      call Turb_Mod_Calculate_Stress   (turb)
       call Turb_Mod_Calculate_Heat_Flux(turb)
       call Turb_Mod_Compute_Variable(turb, sol, ini, turb % t2, n)
     end if
@@ -49,6 +50,7 @@
     call Turb_Mod_Compute_Variable(turb, sol, ini, turb % eps, n)
 
     if(heat_transfer) then
+      call Turb_Mod_Calculate_Stress   (turb)
       call Turb_Mod_Calculate_Heat_Flux(turb)
       call Turb_Mod_Compute_Variable(turb, sol, ini, turb % t2, n)
     end if


### PR DESCRIPTION
Dear Egor and Muhamed,


Massimo and me noticed that Reynolds stresses are not calculated when GGDH heat transfer model is used.  With this pull request, we fixed this.  While doing so, we also noticed that turbulent heat fluxes are not saved in VTU format for RS models.  We fixed it too.  Also, c_theta was missing in single point closure models and we re-introduced it.

We didn't yet fully validate the results.  We were using Rans/Channel_Re_Tau_590 which is usually used for RSM models, and we ran it for k_eps_zeta_f.  The results between RSM and k_eps_zeta_f/GGDH were simular, but we didn't make a thorough analysis and all the plots and all. 

