### PR TITLE
Two little fixes

### DIFF
--- a/Sources/Process/Load_Boundary_Conditions.f90
+++ b/Sources/Process/Load_Boundary_Conditions.f90
@@ -709,6 +709,7 @@
           end do  ! c = -1, -grid % n_bnd_cells, -1
         end if  ! plane is defined?
         close(fu)
+        if( grid % bnd_cond % type(bc) == INFLOW ) deallocate(prof)
       end if  ! boundary defined in a file
     end do
 

--- a/Sources/Process/Turb_Mod/Allocate.f90
+++ b/Sources/Process/Turb_Mod/Allocate.f90
@@ -100,6 +100,10 @@
 
     end if ! turbulence_statistics
 
+    if(buoyancy) then
+      allocate(turb % g_buoy(-nb:nc));  turb % g_buoy = 0.
+    end if ! buoyancy
+
   end if ! K_EPS
 
   !------------------!


### PR DESCRIPTION
Muhamed found a problem with allocation of memory for inlet profiles in Load_Boundary_Conditions.  My humble me found out that production due to buoyancy doesn't get allocated for k_eps, for if someone decides to use this model (which beginners have a tendency to do), the program crashes.

With this pull request we take care of them both.