### PR TITLE
Avoids exchanging temperature information for problems without heat transfer.

### DIFF
--- a/Sources/Process/User_Mod/Interface_Exchange.f90
+++ b/Sources/Process/User_Mod/Interface_Exchange.f90
@@ -1,7 +1,9 @@
 !==============================================================================!
   subroutine User_Mod_Interface_Exchange(inter, flow, n_dom)
 !------------------------------------------------------------------------------!
-!   Create interface between two grids.                                        !
+!   Exchanges information between two domains for conjugate heat transfer      !
+!   problems.  Clearly, it only makes sense to exchange temperatures if        !
+!   heat transfer flag is set to true.                                         !
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
@@ -15,6 +17,9 @@
                         K  = 2,  &  ! ... conductivity as the second ...
                         WD = 3      ! ... and wall distance as the third
 !==============================================================================!
+
+  ! If not heat transfer, don't exchange temperatures
+  if(.not. heat_transfer) return
 
   !-------------------------------------------!
   !   Store the desired values to interface   !


### PR DESCRIPTION
Dear Egor, 

with this commit and pull request I keep the default `User_Mod/Interface_Exchange.f90` to exchange temperature information at the interface (for as I argued that will most likely be needed by users) but I get out of the function in case `heat_transfer` flag is not set to `.true.`

Alternatively, we can leave this function empty, and always compile `T-Flows` with `CASE_DIR` option engaged if someone wants to run problems with two domains.  I am OK with both solutions.