### PR TITLE
Vis t improved for keps

### DIFF
--- a/Sources/Process/Turb_Mod/Vis_T_K_Eps.f90
+++ b/Sources/Process/Turb_Mod/Vis_T_K_Eps.f90
@@ -73,8 +73,8 @@
     f_mu = min(1.0,f_mu)
 
     turb % vis_t(c) = min(f_mu * c_mu * flow % density(c) * kin % n(c)**2  &
-                      / (eps % n(c) + TINY), 0.6*kin % n(c)                &
-                      / (sqrt(6.0)*c_mu*flow % shear(c) + TINY)) 
+                    / (eps % n(c) + TINY), 0.6*kin % n(c)                  &
+                    / (sqrt(6.0)*c_mu*flow % shear(c) + TINY)) 
   end do
 
   do s = 1, grid % n_faces

--- a/Sources/Process/Turb_Mod/Vis_T_K_Eps.f90
+++ b/Sources/Process/Turb_Mod/Vis_T_K_Eps.f90
@@ -72,8 +72,9 @@
 
     f_mu = min(1.0,f_mu)
 
-    turb % vis_t(c) = f_mu * c_mu * flow % density(c) * kin % n(c)**2  &
-                    / eps % n(c)
+    turb % vis_t(c) = min(f_mu * c_mu * flow % density(c) * kin % n(c)**2  &
+                      / (eps % n(c) + TINY), 0.6*kin % n(c)                &
+                      / (sqrt(6.0)*c_mu*flow % shear(c) + TINY)) 
   end do
 
   do s = 1, grid % n_faces

--- a/Tests/Rans/Impinging_Jet_2d_Distant_Re_23000/User_Mod/Impinging_Jet_Profiles.f90
+++ b/Tests/Rans/Impinging_Jet_2d_Distant_Re_23000/User_Mod/Impinging_Jet_Profiles.f90
@@ -142,13 +142,13 @@
             vm_p(i)   = vm_p(i) + u_rad
             wm_p(i)   = wm_p(i) + w % n(c)
 
-            if(turbulence_model .eq. K_EPS) then
+            if(turb % model .eq. K_EPS) then
               v1_p(i) = v1_p(i) + kin % n(c)
               v2_p(i) = v2_p(i) + eps % n(c)
               v3_p(i) = v3_p(i) + turb % vis_t(c) / flow % viscosity(c)
             end if
 
-            if(turbulence_model .eq. K_EPS_ZETA_F) then
+            if(turb % model .eq. K_EPS_ZETA_F) then
               v1_p(i)   = v1_p(i) + kin % n(c)
               v2_p(i)   = v2_p(i) + eps % n(c)
               v3_p(i)   = v3_p(i) + turb % vis_t(c) / flow % viscosity(c)

--- a/Tests/Rans/Pipe_Re_Tau_550/User_Mod/Save_Results.f90
+++ b/Tests/Rans/Pipe_Re_Tau_550/User_Mod/Save_Results.f90
@@ -156,7 +156,7 @@
         vis_t_p(i) = vis_t_p(i) + vis_t(c) / visc_const
         y_plus_p(i)= y_plus_p(i) + turb % y_plus(c)
 
-        if(turbulence_model .eq. K_EPS_ZETA_F) then
+        if(turb % model .eq. K_EPS_ZETA_F) then
           f22_p(i)  = f22_p(i) + f22  % n(c)
           zeta_p(i) = zeta_p(i) + zeta % n(c)
         end if
@@ -322,7 +322,7 @@
       'correlation of Dittus-Boelter is used.' 
     end if
 
-    if(turbulence_model .eq. K_EPS) then
+    if(turb % model .eq. K_EPS) then
       if(heat_transfer) then
         write(i,'(a1,2X,A60)') '#',  ' r,'                    //  &  !  1
                                      ' w,'                    //  &  !  2
@@ -334,7 +334,7 @@
                                     ' w,'                    //  &       !  2
                                     ' kin, eps, uw, vis_t/visc_const'  !  3-6
       end if
-    else if(turbulence_model .eq. K_EPS_ZETA_F) then
+    else if(turb % model .eq. K_EPS_ZETA_F) then
       if(heat_transfer) then
         write(i,'(a1,2X,A60)') '#',  ' r,'                    //  &  !  1
                                      ' w,'                    //  &  !  2
@@ -395,7 +395,7 @@
     eps_p (i) = eps_p(i)*visc_const / (u_tau_p**4*dens_const)  ! eps%n(c)
     uw_p  (i) = uw_p (i) / (u_tau_p**2*dens_const)    ! vis_t(c)*(u%z(c)+w%x(c))
 
-    if(turbulence_model .eq. K_EPS_ZETA_F) then
+    if(turb % model .eq. K_EPS_ZETA_F) then
       f22_p(i) = f22_p(i) * visc_const / u_tau_p**2  ! f22%n(c)
     end if
  


### PR DESCRIPTION
I imposed Durbin's limiter on VISt calculated by k-eps model. This helps in some cases to avoid divergence and stabilize computations. In addition, a few minor bugs in user functions have been fixed.