### PR TITLE
Script test_build.sh adds branch name to log file

### DIFF
--- a/Tests/Les/Rayleigh_Benard_Convection_Ra_10e09/generate.scr
+++ b/Tests/Les/Rayleigh_Benard_Convection_Ra_10e09/generate.scr
@@ -1,0 +1,5 @@
+rb_conv
+1 2
+skip
+skip
+

--- a/Tests/test_build.sh
+++ b/Tests/test_build.sh
@@ -371,7 +371,8 @@ PROC_EXE=$BINA_DIR/Process         # Process  executable
 current_time=$(date +%s)
 
 # Script logs
-FULL_LOG=$TEST_DIR/test_build.$(date +%y-%m-%d-%T).log  # script's logs file
+BRANCH_NAME=$(git branch -a | grep '\*' | awk '{print $2}')
+FULL_LOG=$TEST_DIR/test_branch_$BRANCH_NAME.$(date +%y-%m-%d-%T).log  # script's logs file
 if [ -f $FULL_LOG ]; then cp /dev/null $FULL_LOG; fi
 
 # Keep track of the last executed command


### PR DESCRIPTION
Dear Hamo,

This is a very small modification.  Our test_build.sh script used to create files of the form: test_build.date.time.... which is neat, but one doesn't know which branch was tested which is quite an important piece of information.  This pull requests takes care of it.  Script test_build.sh now creates a file of the form: test_branch_name_of_the_branch.date.time.

Also, while performing tests, I realized that generate.scr got missing from Les/Rayleigh_Benard_Convection_Ra_10e09 so I simply added it back.

On branch main

new file:   Les/Rayleigh_Benard_Convection_Ra_10e09/generate.scr
modified:   test_build.sh