### PR TITLE
Bojan fixes node sorting for concave faces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,3 @@ Tests/**/*tex
 Tests/**/*tmp
 Tests/**/control_template_*
 __pycache__
-# Runtime postprocessing output (do NOT commit)
-*-ts*.dat
-out_*.dat

--- a/Sources/Convert/Convert_Mod.f90
+++ b/Sources/Convert/Convert_Mod.f90
@@ -1,5 +1,6 @@
 #include "../Shared/Assert.h90"
 #include "../Shared/Browse.h90"
+#include "../Shared/Macros.h90"
 #include "../Shared/Unused.h90"
 
 !==============================================================================!
@@ -47,6 +48,7 @@
       procedure          :: Logo_Con
       procedure, private :: N_Bnd_Cells_In_Region
       procedure, private :: N_Edges_In_Region
+      procedure, private :: N_Nodes_At_Boundary
       procedure, private :: N_Nodes_In_Region
       procedure, private :: N_Sharp_Corners
       procedure, private :: N_Sharp_Edges
@@ -181,6 +183,7 @@
 #   include "Convert_Mod/Logo_Con.f90"
 #   include "Convert_Mod/N_Bnd_Cells_In_Region.f90"
 #   include "Convert_Mod/N_Edges_In_Region.f90"
+#   include "Convert_Mod/N_Nodes_At_Boundary.f90"
 #   include "Convert_Mod/N_Nodes_In_Region.f90"
 #   include "Convert_Mod/N_Sharp_Corners.f90"
 #   include "Convert_Mod/N_Sharp_Edges.f90"

--- a/Sources/Convert/Convert_Mod/Create_Dual.f90
+++ b/Sources/Convert/Convert_Mod/Create_Dual.f90
@@ -46,7 +46,7 @@
   integer              :: c_p_list(2048)      ! prim cell and ...
   integer              :: n_d_list(2048)      ! ... dual node list
   integer              :: curr_s_d, curr_b_d, unused, dual_f_here
-  logical              :: issue_warning, found
+  logical              :: error_occured, found
   real                 :: nx, ny, nz, delta
   real,    allocatable :: prim_node_dx(:,:)
   real,    allocatable :: prim_node_dy(:,:)
@@ -380,6 +380,8 @@
       ! Dual face ambiguous.  Store the two boundary-side Dual nodes
       ! linked to this extra node; Sort_Face_Nodes uses this as a
       ! local sorting hint.
+      !
+      ! Note: tests showed that concave_link_cnt after this step is 1
       if(prim_sharp_edge_flag(e_p) .eq. -1) then
         ! print *, ' # Sharp edge:', e_p
         do i_edg = sorted_edge_f(e_p), sorted_edge_l(e_p)
@@ -387,13 +389,18 @@
           c2_p = Prim % faces_c(2, s_p)
           n2_d = c2_p + Prim % n_bnd_cells + 1
           if(c2_p .lt. 0) then
-            if(concave_link(1, d_nn) .eq. 0) then
-              concave_link(1, d_nn) = n2_d
-            else if(concave_link(2, d_nn) .eq. 0) then
-              concave_link(2, d_nn) = n2_d
-            else
-              print *, '# Well, well, this is pretty wrong!'
+            cnt = concave_link_cnt(d_nn)
+
+            ! If cnt==0, it checks pair (1,2), if cnt==1, it checks ...
+            ! ... pair (3,4) and if cnt==2, it checks pair (5,6)
+            if(     concave_link(cnt*2 + 1, d_nn) .eq. 0) then
+                    concave_link(cnt*2 + 1, d_nn) = n2_d
+            else if(concave_link(cnt*2 + 2, d_nn) .eq. 0) then
+                    concave_link(cnt*2 + 2, d_nn) = n2_d
+              cnt = cnt + 1
             end if
+
+            concave_link_cnt(d_nn) = cnt
           end if
         end do
       end if
@@ -437,7 +444,7 @@
   allocate(prim_bnd_cell_flag_in_reg(-Prim % n_bnd_cells:Prim % n_cells))
   prim_bnd_cell_flag_in_reg(:) = 0
 
-  issue_warning = .false.
+  error_occured = .false.
 
   do bc = 1, Prim % n_bnd_regions
 
@@ -585,10 +592,11 @@
               ! of a cube.  In that case concave_link_cnt(n_d) counts how many
               ! edge-neighbour pairs were attached to the same sharp-corner
               ! node.  The pairs are stored in concave_link at first index
-              ! positions (1,2), (3,4), and (5,6).  It seems, from the tests
-              ! that concave_link_cnt can be either 1 or 3, not 2.
+              ! positions (1,2), (3,4), and (5,6).
+              !
+              ! Note: tests showed that concave_link_cnt after this step is 3
               if(concave_link_cnt(n_d) .gt. 3) then
-                issue_warning = .true.
+                error_occured = .true.
               end if
             end if  ! sharp inject in s_d
           end if    ! sharp corner here
@@ -599,14 +607,15 @@
 
   end do  ! bc, boundary region
 
-  if(issue_warning) then
-    print *, '#=============================================='
-    print *, '# Note: sharp-corner Dual nodes with multiple'
-    print *, '#       edge links were detected.'
-    print *, '#       This is expected at domain corners where'
-    print *, '#       several sharp boundary edges meet.'
-    print *, '# Maximum concave link count: ', maxval(concave_link_cnt)
-    print *, '#----------------------------------------------'
+  if(error_occured) then
+    call Message % Error(66, "Dual nodes which are sharp corners "     //     &
+                             "(such a eight cube corners) with more "  //     &
+                             "than three coinciding edges found. "     //     &
+                             "\n \n "                                  //     &
+                             "Such a situation haven't been predicted "//     &
+                             "and the program will have to stop. "     //     &
+                             "Contact the authors and send them this grid.",  &
+                             file = __FILE__, line = __LINE__)
   end if
 
   ! De-allocate what you won't need any more

--- a/Sources/Convert/Convert_Mod/Create_Dual.f90
+++ b/Sources/Convert/Convert_Mod/Create_Dual.f90
@@ -13,31 +13,6 @@
 !   * To make the dual grid suitable near boundaries and sharp geometric       !
 !     features, additional dual nodes are introduced for boundary closure,     !
 !     sharp edges, and sharp corners.                                          !
-!                                                                              !
-!   Functionality                                                              !
-!                                                                              !
-!   * Initial setup: Sets up the problem name for the dual grid and marks it   !
-!     as polyhedral.                                                           !
-!   * Edge processing: Looks for edges in the primal grid and stores their     !
-!     information.                                                             !
-!   * Edge sorting and compression: sorts all primal edges by their node       !
-!     numbers and compresses them to eliminate duplicates.                     !
-!   * Allocate mappings and arrays: Allocates memory for various arrays and    !
-!     mappings, such as those relating edges to nodes and cells to nodes.      !
-!   * Boundary conditions processing: Processes boundary conditions, including !
-!     updating the number of boundary cells and faces in the dual grid.        !
-!   * Inside mapping: Maps nodes of the primal grid to cells of the dual grid, !
-!     edges of the primal to faces of the dual, and cells of the primal to     !
-!     nodes of the dual.                                                       !
-!   * Memory allocation for dual grid: Allocates memory for the dual grid      !
-!     based on the calculated sizes of various components.                     !
-!   * Handling sharp edges and corners: Processes sharp edges and corners in   !
-!     the primal grid and reflects these in the dual grid structure.           !
-!   * Face and cell assembly in dual grid: Assembles faces and cells in the    !
-!     dual grid based on the primal-to-dual mappings.                          !
-!   * Final Adjustments: Makes final adjustments to the structure of the dual  !
-!     grid, ensuring that it accurately represents the topology of the primal  !
-!     grid.                                                                    !
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
@@ -51,7 +26,6 @@
   integer              :: i, i_nod, j_nod, i_edg, i_nor, nn
   integer              :: n_bc, d_nn  ! number of BCs and Dual grid node number
   integer              :: s_p, s_d, b_d, c_p, c_d, cnt
-  integer              :: cnt_ins, cnt_bnd
   integer, allocatable :: full_edge_n (:,:)  ! edges, nodes
   integer, allocatable :: full_edge_fb(:)    ! edges' faces at boundary
   integer, allocatable :: full_edge_bc(:)    ! edges' faces boundary regions
@@ -68,11 +42,11 @@
   integer, allocatable :: prim_sharp_edge_flag(:)
   integer, allocatable :: sharp_inject(:)     ! sharp corner injected in Dual
   integer, allocatable :: concave_link(:,:)
+  integer, allocatable :: concave_link_cnt(:)
   integer              :: c_p_list(2048)      ! prim cell and ...
   integer              :: n_d_list(2048)      ! ... dual node list
   integer              :: curr_s_d, curr_b_d, unused, dual_f_here
   logical              :: issue_warning, found
-  real                 :: xc_ins, yc_ins, zc_ins, xc_bnd, yc_bnd, zc_bnd
   real                 :: nx, ny, nz, delta
   real,    allocatable :: prim_node_dx(:,:)
   real,    allocatable :: prim_node_dy(:,:)
@@ -306,18 +280,25 @@
 
   ! ... and allocate memory for the Dual grid
   call Convert % Allocate_Memory(Dual)
-  allocate(concave_link(2, Dual % n_nodes));  concave_link(:,:) = 0
-  allocate(sharp_inject(   Dual % n_faces));  sharp_inject(:)   = 0
+  allocate(concave_link(6,  Dual % n_nodes));  concave_link(:,:)   = 0
+  allocate(concave_link_cnt(Dual % n_nodes));  concave_link_cnt(:) = 0
+  allocate(sharp_inject(    Dual % n_faces));  sharp_inject(:)     = 0
 
   ! Find sharp corners (nodes) in the Prim grid
   print *, '# Number of sharp corners = ',  &
             Convert % N_Sharp_Corners(Prim, prim_sharp_node_rank)
 
-  !-----------------------------------------!
-  !                                         !
-  !   Browse through all the edges to map   !
-  !                                         !
-  !-----------------------------------------!
+  !----------------------------------------------!
+  !                                              !
+  !   Form internal Dual faces from Prim edges   !
+  !                                              !
+  !- - - - - - - - - - - - - - - - - - - - - - - +-------!
+  !   * Each Prim edge becomes one internal Dual face.   !
+  !   * The two end nodes of the Prim edge become the    !
+  !     two neighbouring Dual cells of that face.        !
+  !   * The Prim cells surrounding the edge become       !
+  !     the nodes of the Dual face.                      !
+  !------------------------------------------------------!
   d_nn = Prim % n_cells + Prim % n_bnd_cells  ! cells(Prim) =--> nodes(Dual)
 
   do e_p = 1, Prim % n_edges
@@ -394,9 +375,11 @@
       Dual % yn(d_nn) = (Prim % yn(n1_p) + Prim % yn(n2_p)) * 0.5
       Dual % zn(d_nn) = (Prim % zn(n1_p) + Prim % zn(n2_p)) * 0.5
 
-      ! Mark node in the concave corner.  It seems impossible
-      ! sort out the direction of nodes for a concave face
-      ! Retreive boundary face information again
+      ! For a concave sharp edge, the extra Dual node inserted at the
+      ! edge midpoint can make the node ordering of the corresponding
+      ! Dual face ambiguous.  Store the two boundary-side Dual nodes
+      ! linked to this extra node; Sort_Face_Nodes uses this as a
+      ! local sorting hint.
       if(prim_sharp_edge_flag(e_p) .eq. -1) then
         ! print *, ' # Sharp edge:', e_p
         do i_edg = sorted_edge_f(e_p), sorted_edge_l(e_p)
@@ -428,21 +411,20 @@
   deallocate(full_edge_fb)
 
   !---------------------------------------!
-  !                                       !
   !   Sort the points on internal faces   !
-  !                                       !
   !---------------------------------------!
   do s_d = 1, Prim % n_edges  ! edges(Prim) =--> faces(Dual)
-    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link)
+    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link, concave_link_cnt)
   end do
-  concave_link(:,:) = 0  ! reset concave links since they ...
-                         ! ... will now be used for inside faces
+  concave_link(:,:)   = 0  ! reset concave links since they ...
+                           ! ... will now be used for inside faces
+  concave_link_cnt(:) = 0
 
-  !----------------------------------!
-  !                                  !
-  !   Boundary mapping               !
-  !                                  !
-  !----------------------------------!
+  !-------------------------------------------------------------------!
+  !                                                                   !
+  !   Form boundary Dual faces from boundary cells of the Prim grid   !
+  !                                                                   !
+  !-------------------------------------------------------------------!
 
   ! Update current number of Dual faces -> equal to the number of faces inside
   curr_s_d = Prim % n_edges
@@ -455,11 +437,13 @@
   allocate(prim_bnd_cell_flag_in_reg(-Prim % n_bnd_cells:Prim % n_cells))
   prim_bnd_cell_flag_in_reg(:) = 0
 
+  issue_warning = .false.
+
   do bc = 1, Prim % n_bnd_regions
 
-    !-----------------------------------------------------!
-    !   Call this to mark boundary cells in this region   !
-    !-----------------------------------------------------!
+    !---------------------------------------------------------------!
+    !   Call this to mark boundary nodes and cells in this region   !
+    !---------------------------------------------------------------!
     dual_f_here = Convert % N_Nodes_In_Region    (Prim, bc,  &
                                                   prim_node_rank_in_reg)
     unused      = Convert % N_Bnd_Cells_In_Region(Prim, bc,  &
@@ -469,7 +453,7 @@
     !   Find Dual's boundary face, and Dual   !
     !   boundary cell nodes from Prim cells   !
     !-----------------------------------------!
-    do c_p = -Prim % n_bnd_cells, -1
+    do c_p = -Prim % n_bnd_cells, -1  ! boundary cells of the Prim grid
       if(prim_bnd_cell_flag_in_reg(c_p) .ne. 0) then
 
         ! Take the Prim cell's nodes (these are from Prim)
@@ -482,7 +466,8 @@
           Dual % faces_n(Dual % faces_n_nodes(s_d), s_d) = cell_to_node(c_p)
 
           ! Additional boundary cell in the Dual grid
-          b_d  = curr_b_d - prim_node_rank_in_reg(n_p)
+          b_d  = curr_b_d - prim_node_rank_in_reg(n_p)  ! boundary cells have
+                                                        ! negative indices
           Dual % cells_n_nodes(b_d) = Dual % cells_n_nodes(b_d) + 1
           call Enlarge % Matrix_Int(Dual % cells_n,  &
                                     i=(/1,Dual % cells_n_nodes(b_d)/))
@@ -502,13 +487,14 @@
       end if
     end do
 
-    ! Update current number of Dual faces
+    ! Update current number of Dual faces and dual boundary cells
     curr_s_d = curr_s_d + dual_f_here
     curr_b_d = curr_b_d - dual_f_here
 
     !---------------------------------------------------------!
     !   Add additional nodes to Dual's face from Prim edges   !
-    !   Here we work on the faces already introduced above    !
+    !      (Note that here we work on the faces already       !
+    !       introduced above, just adding more nodes)         !
     !---------------------------------------------------------!
     unused = Convert % N_Edges_In_Region(Prim, bc, prim_edge_flag_in_reg)
 
@@ -539,9 +525,9 @@
 
     !------------------------------------------------------------!
     !   Add additional nodes to Dual's face from sharp corners   !
-    !    Here we work on the faces already introduced before     !
+    !        (Note that here we work on the faces already        !
+    !         introduced above, just adding more nodes)          !
     !------------------------------------------------------------!
-    issue_warning = .false.
     do e_p = 1, Prim % n_edges
       if(prim_edge_flag_in_reg(e_p) .ne. 0) then
 
@@ -549,6 +535,8 @@
           n_p = Prim % edges_n(i_nod, e_p)
           s_d = node_to_face(n_p)
           b_d = node_to_cell(n_p)
+
+          Assert(s_d .gt. Prim % n_edges)
 
           ! The grid has sharp corners, add them to boundary faces and cells
           if(prim_sharp_node_rank(n_p) .gt. 0) then
@@ -561,11 +549,13 @@
               Dual % yn(n_d) = Prim % yn(n_p)
               Dual % zn(n_d) = Prim % zn(n_p)
 
+              ! Insert a new node from the edge to the bundary face
               Dual % faces_n_nodes(s_d) = Dual % faces_n_nodes(s_d) + 1
               call Enlarge % Matrix_Int(Dual % faces_n,  &
                                         i=(/1,Dual % faces_n_nodes(s_d)/))
               Dual % faces_n(Dual % faces_n_nodes(s_d), s_d) = n_d
 
+              ! Insert a new node from the edge to the bundary cell
               Dual % cells_n_nodes(b_d) = Dual % cells_n_nodes(b_d) + 1
               call Enlarge % Matrix_Int(Dual % cells_n,  &
                                         i=(/1,Dual % cells_n_nodes(b_d)/))
@@ -578,14 +568,28 @@
               ! Check those little nodes inserted just before
               n1_d = Dual % faces_n(Dual % faces_n_nodes(s_d)-2, s_d)
               n2_d = Dual % faces_n(Dual % faces_n_nodes(s_d)-1, s_d)
-              if(concave_link(1,n_d) .eq. 0 .and.  &
-                 concave_link(2,n_d) .eq. 0) then
-                concave_link(1,n_d) = n1_d
-                concave_link(2,n_d) = n2_d
-              else
+
+              ! Increase the concave link count for this node
+              concave_link_cnt(n_d) = concave_link_cnt(n_d) + 1
+
+              ! Store the first concave link for this node
+              cnt = concave_link_cnt(n_d)
+
+              ! Fill paris 1,2 or 3,4 or 5,6
+              concave_link(cnt*2 - 1, n_d) = n1_d
+              concave_link(cnt*2,     n_d) = n2_d
+
+              ! A sharp-corner Dual node can be reached from more than one
+              ! boundary edge. This is expected at domain vertices where
+              ! several sharp edges meet, for example at the eight corners
+              ! of a cube.  In that case concave_link_cnt(n_d) counts how many
+              ! edge-neighbour pairs were attached to the same sharp-corner
+              ! node.  The pairs are stored in concave_link at first index
+              ! positions (1,2), (3,4), and (5,6).  It seems, from the tests
+              ! that concave_link_cnt can be either 1 or 3, not 2.
+              if(concave_link_cnt(n_d) .gt. 3) then
                 issue_warning = .true.
               end if
-
             end if  ! sharp inject in s_d
           end if    ! sharp corner here
 
@@ -593,17 +597,26 @@
       end if    ! edge is in the region
     end do      ! through edges
 
-    if(issue_warning) then
-      print *, '# Well, you didn''t see this coming!'
-      print *, '# One sharp corner can be in more than one edge'
-    end if
-
   end do  ! bc, boundary region
 
+  if(issue_warning) then
+    print *, '#=============================================='
+    print *, '# Note: sharp-corner Dual nodes with multiple'
+    print *, '#       edge links were detected.'
+    print *, '#       This is expected at domain corners where'
+    print *, '#       several sharp boundary edges meet.'
+    print *, '# Maximum concave link count: ', maxval(concave_link_cnt)
+    print *, '#----------------------------------------------'
+  end if
+
   ! De-allocate what you won't need any more
-  deallocate(cell_to_node)
-  deallocate(node_to_face)
+  deallocate(sharp_inject)
+  deallocate(prim_sharp_node_rank)
+  deallocate(prim_node_rank_in_reg)
+  deallocate(edge_to_node)
   deallocate(node_to_cell)
+  deallocate(node_to_face)
+  deallocate(cell_to_node)
 
   !---------------------------------------!
   !                                       !
@@ -611,8 +624,11 @@
   !                                       !
   !---------------------------------------!
   do s_d = Prim % n_edges + 1, Dual % n_faces
-    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link)
+    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link, concave_link_cnt)
   end do
+
+  deallocate(concave_link_cnt)
+  deallocate(concave_link)
 
   !------------------------------------------------------------!
   !   Save only internal faces to see if sorting of boundary   !
@@ -785,16 +801,16 @@
               prim_node_n_norms(n_p) = prim_node_n_norms(n_p) + 1
               nn = prim_node_n_norms(n_p)
               call Enlarge % Matrix_Real(prim_node_dx,  &
-                                         i=(/1,nn/),     &
+                                         i=(/1,nn/),    &
                                          j=(/1,Prim % n_nodes/))
               call Enlarge % Matrix_Real(prim_node_dy,  &
-                                         i=(/1,nn/),     &
+                                         i=(/1,nn/),    &
                                          j=(/1,Prim % n_nodes/))
               call Enlarge % Matrix_Real(prim_node_dz,  &
-                                         i=(/1,nn/),     &
+                                         i=(/1,nn/),    &
                                          j=(/1,Prim % n_nodes/))
               call Enlarge % Matrix_Real(prim_node_d,   &
-                                         i=(/1,1/),     &
+                                         i=(/1,nn/),    &
                                          j=(/1,Prim % n_nodes/))
               prim_node_dx(nn, n_p) = nx
               prim_node_dy(nn, n_p) = ny

--- a/Sources/Convert/Convert_Mod/Create_Dual.f90
+++ b/Sources/Convert/Convert_Mod/Create_Dual.f90
@@ -26,6 +26,7 @@
   integer              :: i, i_nod, j_nod, i_edg, i_nor, nn
   integer              :: n_bc, d_nn  ! number of BCs and Dual grid node number
   integer              :: s_p, s_d, b_d, c_p, c_d, cnt
+  integer              :: n_prim_sharp_c, n_prim_sharp_e
   integer, allocatable :: full_edge_n (:,:)  ! edges, nodes
   integer, allocatable :: full_edge_fb(:)    ! edges' faces at boundary
   integer, allocatable :: full_edge_bc(:)    ! edges' faces boundary regions
@@ -188,7 +189,7 @@
   end do
   sorted_edge_l(Prim % n_edges) = e_p-1  ! mark the end of the last edge
 
-  ! De-allocate two full_edge_... array
+  ! De-allocate two full_edge_... arrays
   ! full_edge_n  -> not needed after compressed Prim % edges_n is built
   ! full_edge_bc -> not needed after Prim % edges_bc / Prim % edges_fb are built
   ! full_edge_fb -> still needed for mapping, for it contains list of faces
@@ -217,12 +218,17 @@
   allocate(edge_to_node( Prim % n_edges));  edge_to_node(:) = 0
 
   allocate(prim_sharp_edge_flag(Prim % n_edges))
-  prim_sharp_edge_flag(:) = 0
+  allocate(prim_sharp_node_rank( Prim % n_nodes))
 
-  !----------------------!
-  !   Plot sharp edges   !
-  !----------------------!
-  unused = Convert % N_Sharp_Edges(Prim, prim_sharp_edge_flag)
+  !--------------------------------!
+  !   Find sharp edges and nodes   !
+  !--------------------------------!
+  n_prim_sharp_e = Convert % N_Sharp_Edges(Prim,  &
+                                           prim_sharp_edge_flag)
+  n_prim_sharp_c = Convert % N_Sharp_Corners(Prim,                  &
+                                             prim_sharp_edge_flag,  &
+                                             prim_sharp_node_rank)
+  ! Plot sharp edges for checking
   call Prim % Save_Vtu_Edges(prim_sharp_edge_flag)  ! -1, 0, +1
 
   !-------------------------!
@@ -260,7 +266,6 @@
   ! Allocate memory to store node ranks in a region
   ! and the node ranks for sharp nodes (corners)
   allocate(prim_node_rank_in_reg(Prim % n_nodes))
-  allocate(prim_sharp_node_rank( Prim % n_nodes))
 
   ! Increase total number of boundary cells in Dual
   do bc = 1, Prim % n_bnd_regions
@@ -273,10 +278,10 @@
   Dual % n_faces = Prim % n_edges  &   ! for faces inside
                  + Dual % n_bnd_cells  ! for faces on the boundary
   Dual % n_cells = Prim % n_nodes
-  Dual % n_nodes = Prim % n_cells                                         &
-                 + Prim % n_bnd_cells                                     &
-                 + Convert % N_Sharp_Edges(Prim, prim_sharp_edge_flag)    &
-                 + Convert % N_Sharp_Corners(Prim, prim_sharp_node_rank)
+  Dual % n_nodes = Prim % n_cells       &
+                 + Prim % n_bnd_cells   &
+                 + n_prim_sharp_e       &
+                 + n_prim_sharp_c
 
   ! ... and allocate memory for the Dual grid
   call Convert % Allocate_Memory(Dual)
@@ -285,8 +290,7 @@
   allocate(sharp_inject(    Dual % n_faces));  sharp_inject(:)     = 0
 
   ! Find sharp corners (nodes) in the Prim grid
-  print *, '# Number of sharp corners = ',  &
-            Convert % N_Sharp_Corners(Prim, prim_sharp_node_rank)
+  print *, '# Number of sharp corners = ', n_prim_sharp_c
 
   !----------------------------------------------!
   !                                              !
@@ -856,7 +860,7 @@
         Dual % zc(c_d) = Dual % zc(c_d) - prim_node_dz(i_nor, n_p) * delta
       end do
       if(DEBUG) then
-        call Dual % Save_Vtk_Cell(c_d, "concave_cell", c_d)
+        call Dual % Save_Vtk_Cell(c_d, "concave_cell", c_d, plot_center=.true.)
       end if
     end if
   end do

--- a/Sources/Convert/Convert_Mod/Create_Dual.f90
+++ b/Sources/Convert/Convert_Mod/Create_Dual.f90
@@ -4,13 +4,23 @@
 !>  Creates a dual grid based on the given primal grid.  The dual grid concept
 !>  is used here to create a polyhedral grid out of a tetrahedral.
 !------------------------------------------------------------------------------!
+!   Philosophy                                                                 !
+!                                                                              !
+!   * This routine converts a tetrahedral primal grid into a polyhedral dual   !
+!     grid. The basic idea is that each primal node becomes a dual cell, each  !
+!     primal edge becomes a dual face, and each primal cell becomes a dual     !
+!     node.                                                                    !
+!   * To make the dual grid suitable near boundaries and sharp geometric       !
+!     features, additional dual nodes are introduced for boundary closure,     !
+!     sharp edges, and sharp corners.                                          !
+!                                                                              !
 !   Functionality                                                              !
 !                                                                              !
 !   * Initial setup: Sets up the problem name for the dual grid and marks it   !
 !     as polyhedral.                                                           !
 !   * Edge processing: Looks for edges in the primal grid and stores their     !
 !     information.                                                             !
-!   * Edge sorting and compression: Sorts all primal edges by their node       !
+!   * Edge sorting and compression: sorts all primal edges by their node       !
 !     numbers and compresses them to eliminate duplicates.                     !
 !   * Allocate mappings and arrays: Allocates memory for various arrays and    !
 !     mappings, such as those relating edges to nodes and cells to nodes.      !
@@ -33,29 +43,42 @@
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert     !! parent class
   type(Grid_Type)     :: Prim, Dual  !! primal and dual grid
+!------------------------------[Local parameters]------------------------------!
+  logical, parameter :: DEBUG = .false.
 !-----------------------------------[Locals]-----------------------------------!
-  integer              :: bc, e, c, c1, c2, s, n, n1, n2
-  integer              :: i, i_nod, j_nod, i_edg
+  integer              :: bc, e_p, c1_p, c2_p, c1_d, c2_d
+  integer              :: n_p, n_d, n1_p, n2_p, n1_d, n2_d
+  integer              :: i, i_nod, j_nod, i_edg, i_nor, nn
   integer              :: n_bc, d_nn  ! number of BCs and Dual grid node number
-  integer              :: n_p, n_d, f_d, b_d, f_p, c_p, cnt
-  integer, allocatable :: full_edge_n (:,:)   ! edges, nodes
-  integer, allocatable :: full_edge_fb(:)     ! edges' faces at boundary
-  integer, allocatable :: full_edge_bc(:)     ! edges' faces boundary regions
-  integer, allocatable :: comp_edge_f(:)      ! compressed edge first
-  integer, allocatable :: comp_edge_l(:)      ! compressed edge last
+  integer              :: s_p, s_d, b_d, c_p, c_d, cnt
+  integer              :: cnt_ins, cnt_bnd
+  integer, allocatable :: full_edge_n (:,:)  ! edges, nodes
+  integer, allocatable :: full_edge_fb(:)    ! edges' faces at boundary
+  integer, allocatable :: full_edge_bc(:)    ! edges' faces boundary regions
+  integer, allocatable :: sorted_edge_f(:)   ! first and last occurrence in ...
+  integer, allocatable :: sorted_edge_l(:)   ! ... in sorted full_edge_* list
   integer, allocatable :: cell_to_node(:)
   integer, allocatable :: node_to_face(:)
   integer, allocatable :: node_to_cell(:)
   integer, allocatable :: edge_to_node(:)
-  integer, allocatable :: edge_data(:)
-  integer, allocatable :: cell_data(:)
-  integer, allocatable :: node_data(:)
-  integer, allocatable :: sharp_corner(:)     ! sharp corners in Prim
+  integer, allocatable :: prim_bnd_cell_flag_in_reg(:)
+  integer, allocatable :: prim_node_rank_in_reg(:)
+  integer, allocatable :: prim_edge_flag_in_reg(:)
+  integer, allocatable :: prim_sharp_node_rank(:)
+  integer, allocatable :: prim_sharp_edge_flag(:)
   integer, allocatable :: sharp_inject(:)     ! sharp corner injected in Dual
   integer, allocatable :: concave_link(:,:)
-  integer              :: c_p_list(2048)      ! Prim cell and ...
-  integer              :: n_d_list(2048)      ! ... Dual node list
-  integer              :: curr_f_d, curr_b_d, unused, dual_f_here
+  integer              :: c_p_list(2048)      ! prim cell and ...
+  integer              :: n_d_list(2048)      ! ... dual node list
+  integer              :: curr_s_d, curr_b_d, unused, dual_f_here
+  logical              :: issue_warning, found
+  real                 :: xc_ins, yc_ins, zc_ins, xc_bnd, yc_bnd, zc_bnd
+  real                 :: nx, ny, nz, delta
+  real,    allocatable :: prim_node_dx(:,:)
+  real,    allocatable :: prim_node_dy(:,:)
+  real,    allocatable :: prim_node_dz(:,:)
+  real,    allocatable :: prim_node_d (:,:)
+  integer, allocatable :: prim_node_n_norms(:)   ! number of normals
 !==============================================================================!
 
   ! Alias(es)
@@ -82,8 +105,8 @@
   !                                       !
   !---------------------------------------!
   Prim % n_edges = 0
-  do s = 1, Prim % n_faces
-    Prim % n_edges = Prim % n_edges + Prim % faces_n_nodes(s)
+  do s_p = 1, Prim % n_faces
+    Prim % n_edges = Prim % n_edges + Prim % faces_n_nodes(s_p)
   end do
   print *, '# Expanded edges in primal grid:', Prim % n_edges
 
@@ -95,25 +118,27 @@
   !   Pile up all the edges on the Prim grid   !
   !--------------------------------------------!
   Prim % n_edges = 0
-  do s = 1, Prim % n_faces
+  do s_p = 1, Prim % n_faces
 
-    c1 = Prim % faces_c(1, s)
-    c2 = Prim % faces_c(2, s)
+    c1_p = Prim % faces_c(1, s_p)
+    c2_p = Prim % faces_c(2, s_p)
 
-    do i_nod = 1, Prim % faces_n_nodes(s)
-      j_nod = i_nod + 1;  if(j_nod > Prim % faces_n_nodes(s)) j_nod = 1
-      n1 = Prim % faces_n(i_nod, s)
-      n2 = Prim % faces_n(j_nod, s)
+    do i_nod = 1, Prim % faces_n_nodes(s_p)
+      j_nod = i_nod + 1;  if(j_nod > Prim % faces_n_nodes(s_p)) j_nod = 1
+      n1_p = Prim % faces_n(i_nod, s_p)
+      n2_p = Prim % faces_n(j_nod, s_p)
 
       ! Increase the counter and store the data in it
       Prim % n_edges = Prim % n_edges + 1
-      full_edge_n (Prim % n_edges, 1) = min(n1, n2)
-      full_edge_n (Prim % n_edges, 2) = max(n1, n2)
-      full_edge_fb(Prim % n_edges)    =  s
-      if(c2 > 0) then
-        full_edge_bc(Prim % n_edges) = 0  ! not a boundary face
+      full_edge_n (Prim % n_edges, 1) = min(n1_p, n2_p)
+      full_edge_n (Prim % n_edges, 2) = max(n1_p, n2_p)
+      full_edge_fb(Prim % n_edges)    = s_p
+      if(c2_p > 0) then
+        ! Not a boundary face
+        full_edge_bc(Prim % n_edges) = 0
       else
-        full_edge_bc(Prim % n_edges) = Prim % region % at_cell(c2)  ! store reg
+        ! Store region
+        full_edge_bc(Prim % n_edges) = Prim % region % at_cell(c2_p)
       end if
     end do
   end do
@@ -131,10 +156,10 @@
   !   Estimate number of edges compressed   !
   !-----------------------------------------!
   Prim % n_edges = 1
-  do e = 2, size(full_edge_fb)  ! I don't like it, but here it is
-    if(e > 1) then
-      if(full_edge_n (e,1) .ne. full_edge_n (e-1,1) .or.  &
-         full_edge_n (e,2) .ne. full_edge_n (e-1,2)) then
+  do e_p = 2, size(full_edge_fb)  ! I don't like it, but here it is
+    if(e_p > 1) then
+      if(full_edge_n(e_p, 1) .ne. full_edge_n(e_p - 1, 1) .or.  &
+         full_edge_n(e_p, 2) .ne. full_edge_n(e_p - 1, 2)) then
         Prim % n_edges = Prim % n_edges + 1
       end if
     end if
@@ -144,8 +169,8 @@
   !----------------------------------------------------!
   !   Allocate memory for mapping and related arrays   !
   !----------------------------------------------------!
-  allocate(comp_edge_f(Prim % n_edges));  comp_edge_f(:) = 0
-  allocate(comp_edge_l(Prim % n_edges));  comp_edge_l(:) = 0
+  allocate(sorted_edge_f(Prim % n_edges));  sorted_edge_f(:) = 0
+  allocate(sorted_edge_l(Prim % n_edges));  sorted_edge_l(:) = 0
 
   allocate(Prim % edges_n (2,      Prim % n_edges))
   allocate(Prim % edges_bc(0:n_bc, Prim % n_edges))
@@ -158,36 +183,53 @@
   !   Store compressed edges with their information on boundary   !
   !---------------------------------------------------------------!
   Prim % n_edges = 1
-  comp_edge_f(Prim % n_edges) = 1
-  do e = 1, size(full_edge_fb)  ! I don't like it, but here it is
+  sorted_edge_f(Prim % n_edges) = 1
+  do e_p = 1, size(full_edge_fb)  ! I don't like it, but here it is
 
-    if(e > 1) then
-      if(full_edge_n (e, 1) .ne. full_edge_n (e-1, 1) .or.  &
-         full_edge_n (e, 2) .ne. full_edge_n (e-1, 2)) then
-        comp_edge_l(Prim % n_edges) = e-1  ! mark the end of the old edge
+    if(e_p > 1) then
+      if(full_edge_n (e_p, 1) .ne. full_edge_n (e_p-1, 1) .or.  &
+         full_edge_n (e_p, 2) .ne. full_edge_n (e_p-1, 2)) then
+        sorted_edge_l(Prim % n_edges) = e_p-1  ! mark the end of the old edge
         Prim % n_edges = Prim % n_edges + 1
-        comp_edge_f(Prim % n_edges) = e    ! mark the start of the new edge
+        sorted_edge_f(Prim % n_edges) = e_p    ! mark the start of the new edge
       end if
     end if
 
-    Prim % edges_n (1, Prim % n_edges) = full_edge_n(e, 1)
-    Prim % edges_n (2, Prim % n_edges) = full_edge_n(e, 2)
-    Prim % edges_bc(full_edge_bc(e), Prim % n_edges) = 1  ! as if .true.
+    Prim % edges_n (1, Prim % n_edges) = full_edge_n(e_p, 1)
+    Prim % edges_n (2, Prim % n_edges) = full_edge_n(e_p, 2)
+    Prim % edges_bc(full_edge_bc(e_p), Prim % n_edges) = 1  ! as if .true.
 
     ! Saves boundary faces - needed to check if boundary
     ! face angles are too sharp at boundary edges
-    if(full_edge_bc(e) .ne. 0) then
+    if(full_edge_bc(e_p) .ne. 0) then
       if(Prim % edges_fb(1,Prim % n_edges) .eq. 0) then
-         Prim % edges_fb(1,Prim % n_edges) = full_edge_fb(e)
+        Prim % edges_fb(1, Prim % n_edges) = full_edge_fb(e_p)
       else if(Prim % edges_fb(1,Prim % n_edges) .ne. 0) then
-        Prim % edges_fb(2,Prim % n_edges) = full_edge_fb(e)
+        Prim % edges_fb(2, Prim % n_edges) = full_edge_fb(e_p)
       else
         print *, '# ERROR'
       end if
     end if
 
   end do
-  comp_edge_l(Prim % n_edges) = e-1  ! mark the end of the last edge
+  sorted_edge_l(Prim % n_edges) = e_p-1  ! mark the end of the last edge
+
+  ! De-allocate two full_edge_... array
+  ! full_edge_n  -> not needed after compressed Prim % edges_n is built
+  ! full_edge_bc -> not needed after Prim % edges_bc / Prim % edges_fb are built
+  ! full_edge_fb -> still needed for mapping, for it contains list of faces
+  !
+  ! For example, after sorting, these arrays could have the values:
+  !
+  ! i_edg   full_edge_n(:,i_edg)   full_edge_bc(i_edg)   full_edge_fb(i_edg)
+  ! ------------------------------------------------------------------------
+  ! 21      edge (3,7)             4                     face 100
+  ! 22      edge (3,7)             4                     face 124
+  ! 23      edge (3,7)             4                     face 131
+  ! 24      edge (3,7)             4                     face 155
+  ! 25      edge (3,8)             5                     face 102
+  deallocate(full_edge_n)
+  deallocate(full_edge_bc)
 
   !-----------------------!
   !                       !
@@ -196,20 +238,18 @@
   !-----------------------!
   allocate(cell_to_node(-Prim % n_bnd_cells  &
                         :Prim % n_cells));  cell_to_node(:) = 0
-  allocate(sharp_corner( Prim % n_nodes));  sharp_corner(:) = 0
   allocate(node_to_face( Prim % n_nodes));  node_to_face(:) = 0
   allocate(node_to_cell( Prim % n_nodes));  node_to_cell(:) = 0
   allocate(edge_to_node( Prim % n_edges));  edge_to_node(:) = 0
-  allocate(cell_data(-Prim % n_bnd_cells  &
-                     :Prim % n_cells));  cell_data(:) = 0
-  allocate(edge_data( Prim % n_edges));  edge_data(:) = 0
-  allocate(node_data( Prim % n_nodes));  node_data(:) = 0
+
+  allocate(prim_sharp_edge_flag(Prim % n_edges))
+  prim_sharp_edge_flag(:) = 0
 
   !----------------------!
   !   Plot sharp edges   !
   !----------------------!
-  unused = Convert % N_Sharp_Edges(Prim, edge_data)     ! find sharp edges
-  call Prim % Save_Vtu_Edges(edge_data)
+  unused = Convert % N_Sharp_Edges(Prim, prim_sharp_edge_flag)
+  call Prim % Save_Vtu_Edges(prim_sharp_edge_flag)  ! -1, 0, +1
 
   !-------------------------!
   !                         !
@@ -242,51 +282,65 @@
   ! Count boundary cells (and boundary faces) for the Dual grid
   ! (Remember that nodes in Prim correspond to cells in Dual)
   Dual % n_bnd_cells = 0
+
+  ! Allocate memory to store node ranks in a region
+  ! and the node ranks for sharp nodes (corners)
+  allocate(prim_node_rank_in_reg(Prim % n_nodes))
+  allocate(prim_sharp_node_rank( Prim % n_nodes))
+
+  ! Increase total number of boundary cells in Dual
   do bc = 1, Prim % n_bnd_regions
-    Dual % n_bnd_cells = Dual % n_bnd_cells  &
-                       + Convert % N_Nodes_In_Region(Prim, bc, node_data)
+    Dual % n_bnd_cells = Dual % n_bnd_cells                     &
+                       + Convert % N_Nodes_In_Region(Prim, bc,  &
+                                                     prim_node_rank_in_reg)
   end do
+
+  ! Estimate number of faces, cells and nodes in the Dual grid ...
   Dual % n_faces = Prim % n_edges  &   ! for faces inside
                  + Dual % n_bnd_cells  ! for faces on the boundary
   Dual % n_cells = Prim % n_nodes
-  Dual % n_nodes = Prim % n_cells                  &
-                 + Prim % n_bnd_cells              &
-                 + Convert % N_Sharp_Edges(Prim, edge_data)  &
-                 + Convert % N_Sharp_Corners(Prim, sharp_corner)
+  Dual % n_nodes = Prim % n_cells                                         &
+                 + Prim % n_bnd_cells                                     &
+                 + Convert % N_Sharp_Edges(Prim, prim_sharp_edge_flag)    &
+                 + Convert % N_Sharp_Corners(Prim, prim_sharp_node_rank)
 
+  ! ... and allocate memory for the Dual grid
   call Convert % Allocate_Memory(Dual)
   allocate(concave_link(2, Dual % n_nodes));  concave_link(:,:) = 0
   allocate(sharp_inject(   Dual % n_faces));  sharp_inject(:)   = 0
 
+  ! Find sharp corners (nodes) in the Prim grid
   print *, '# Number of sharp corners = ',  &
-            Convert % N_Sharp_Corners(Prim, sharp_corner)
+            Convert % N_Sharp_Corners(Prim, prim_sharp_node_rank)
 
   !-----------------------------------------!
   !                                         !
   !   Browse through all the edges to map   !
   !                                         !
   !-----------------------------------------!
-  d_nn = Prim % n_cells      &
-       + Prim % n_bnd_cells
+  d_nn = Prim % n_cells + Prim % n_bnd_cells  ! cells(Prim) =--> nodes(Dual)
 
-  do e = 1, Prim % n_edges
+  do e_p = 1, Prim % n_edges
 
-    f_d = e
+    ! Face on the Dual grid (s_d) corresponds to the edge of the Prim grid
+    s_d = e_p  ! edges(Prim) =--> faces(Dual)
 
     ! Store cells surrounding each face in the Dual grid ...
     ! ... which correspond to nodes in the Prim grid
-    n1 = Prim % edges_n(1, e)
-    n2 = Prim % edges_n(2, e)
-    Dual % faces_c(1, f_d) = n1
-    Dual % faces_c(2, f_d) = n2
+    n1_p = Prim % edges_n(1, e_p)
+    n2_p = Prim % edges_n(2, e_p)
+    c1_d = n1_p  ! nodes(Prim) =--> cells(Dual)
+    c2_d = n2_p  ! nodes(Prim) =--> cells(Dual)
+    Dual % faces_c(1, s_d) = c1_d
+    Dual % faces_c(2, s_d) = c2_d
 
     ! Store nodes for each face in Dual grid ...
     ! ... which are cells around each edge in Prim
     cnt = 0
-    do i_edg = comp_edge_f(e), comp_edge_l(e)
-      f_p = full_edge_fb(i_edg)       ! get face index from the Prim grid
-      cnt = cnt + 1;  c_p_list(cnt) = Prim % faces_c(1, f_p)
-      cnt = cnt + 1;  c_p_list(cnt) = Prim % faces_c(2, f_p)
+    do i_edg = sorted_edge_f(e_p), sorted_edge_l(e_p)
+      s_p = full_edge_fb(i_edg)       ! get face index from the Prim grid
+      cnt = cnt + 1;  c_p_list(cnt) = Prim % faces_c(1, s_p)
+      cnt = cnt + 1;  c_p_list(cnt) = Prim % faces_c(2, s_p)
     end do
     call Sort % Unique_Int(c_p_list(1:cnt), cnt)
 
@@ -298,9 +352,9 @@
     end do
 
     ! Form Dual's faces' nodes
-    Dual % faces_n_nodes(f_d) = cnt
+    Dual % faces_n_nodes(s_d) = cnt
     call Enlarge % Matrix_Int(Dual % faces_n, i=(/1,cnt/))
-    Dual % faces_n(1:cnt,f_d) = n_d_list(1:cnt)
+    Dual % faces_n(1:cnt,s_d) = n_d_list(1:cnt)
 
     ! Copy node coordinates
     do i = 1, cnt
@@ -321,37 +375,39 @@
     !------------------------------------------------------------!
     !   If the face in a sharp corner, add one more node to it   !
     !------------------------------------------------------------!
-    if(edge_data(e) .ne. 0) then
+    if(prim_sharp_edge_flag(e_p) .ne. 0) then  ! it is -1 or +1
 
       ! Additional Dual node number
       d_nn = d_nn + 1
 
       ! Add extra node to Dual's faces' nodes
-      Dual % faces_n_nodes(f_d) = cnt + 1
+      Dual % faces_n_nodes(s_d) = cnt + 1
       call Enlarge % Matrix_Int(Dual % faces_n, i=(/1,cnt+1/))
-      Dual % faces_n(cnt + 1:cnt + 1, f_d) = d_nn
+      Dual % faces_n(cnt + 1:cnt + 1, s_d) = d_nn
 
       ! Copy extra node coordinates
-      n1 = Prim % edges_n(1, e)
-      n2 = Prim % edges_n(2, e)
-      Dual % xn(d_nn) = (Prim % xn(n1) + Prim % xn(n2)) * 0.5  ! copy coords
-      Dual % yn(d_nn) = (Prim % yn(n1) + Prim % yn(n2)) * 0.5
-      Dual % zn(d_nn) = (Prim % zn(n1) + Prim % zn(n2)) * 0.5
+      n1_p = Prim % edges_n(1, e_p)
+      n2_p = Prim % edges_n(2, e_p)
+
+      ! Copy coordinates
+      Dual % xn(d_nn) = (Prim % xn(n1_p) + Prim % xn(n2_p)) * 0.5
+      Dual % yn(d_nn) = (Prim % yn(n1_p) + Prim % yn(n2_p)) * 0.5
+      Dual % zn(d_nn) = (Prim % zn(n1_p) + Prim % zn(n2_p)) * 0.5
 
       ! Mark node in the concave corner.  It seems impossible
       ! sort out the direction of nodes for a concave face
       ! Retreive boundary face information again
-      if(edge_data(e) .eq. -1) then
-        ! print *, ' # Sharp edge:', e
-        do i_edg = comp_edge_f(e), comp_edge_l(e)
-          f_p = full_edge_fb(i_edg)       ! get face index from the Prim grid
-          c2 = Prim % faces_c(2, f_p)
-          n2 = c2 + Prim % n_bnd_cells + 1
-          if(c2 < 0) then
-            if(concave_link(1,d_nn) .eq. 0) then
-              concave_link(1,d_nn) = n2
-            else if(concave_link(2,d_nn) .eq. 0) then
-              concave_link(2,d_nn) = n2
+      if(prim_sharp_edge_flag(e_p) .eq. -1) then
+        ! print *, ' # Sharp edge:', e_p
+        do i_edg = sorted_edge_f(e_p), sorted_edge_l(e_p)
+          s_p = full_edge_fb(i_edg)       ! get face index from the Prim grid
+          c2_p = Prim % faces_c(2, s_p)
+          n2_d = c2_p + Prim % n_bnd_cells + 1
+          if(c2_p .lt. 0) then
+            if(concave_link(1, d_nn) .eq. 0) then
+              concave_link(1, d_nn) = n2_d
+            else if(concave_link(2, d_nn) .eq. 0) then
+              concave_link(2, d_nn) = n2_d
             else
               print *, '# Well, well, this is pretty wrong!'
             end if
@@ -360,21 +416,27 @@
       end if
 
       ! Store edge to node mapping (Prim edge to Dual node)
-      edge_to_node(e) = d_nn
+      edge_to_node(e_p) = d_nn
 
     end if
 
-  end do  ! through edges
+  end do  ! through edges; e_p
+
+  ! De-allocate arrays you won't need any more
+  deallocate(sorted_edge_f)
+  deallocate(sorted_edge_l)
+  deallocate(full_edge_fb)
 
   !---------------------------------------!
   !                                       !
   !   Sort the points on internal faces   !
   !                                       !
   !---------------------------------------!
-  do s = 1, Prim % n_edges
-    call Convert % Sort_Face_Nodes(Dual, s, concave_link)
+  do s_d = 1, Prim % n_edges  ! edges(Prim) =--> faces(Dual)
+    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link)
   end do
-  concave_link(:,:) = 0  ! reset concave links since they work only for inside faces
+  concave_link(:,:) = 0  ! reset concave links since they ...
+                         ! ... will now be used for inside faces
 
   !----------------------------------!
   !                                  !
@@ -383,83 +445,93 @@
   !----------------------------------!
 
   ! Update current number of Dual faces -> equal to the number of faces inside
-  curr_f_d = Prim % n_edges
+  curr_s_d = Prim % n_edges
   curr_b_d = 0
+
+  ! Allocate memory
+  allocate(prim_edge_flag_in_reg(Prim % n_edges))
+  prim_edge_flag_in_reg(:) = 0
+
+  allocate(prim_bnd_cell_flag_in_reg(-Prim % n_bnd_cells:Prim % n_cells))
+  prim_bnd_cell_flag_in_reg(:) = 0
 
   do bc = 1, Prim % n_bnd_regions
 
     !-----------------------------------------------------!
     !   Call this to mark boundary cells in this region   !
     !-----------------------------------------------------!
-    dual_f_here = Convert % N_Nodes_In_Region(Prim, bc, node_data)
-    unused      = Convert % N_Bnd_Cells_In_Region(Prim, bc, cell_data)
-    unused      = Convert % N_Edges_In_Region(Prim, bc, edge_data)
+    dual_f_here = Convert % N_Nodes_In_Region    (Prim, bc,  &
+                                                  prim_node_rank_in_reg)
+    unused      = Convert % N_Bnd_Cells_In_Region(Prim, bc,  &
+                                                  prim_bnd_cell_flag_in_reg)
 
     !-----------------------------------------!
     !   Find Dual's boundary face, and Dual   !
     !   boundary cell nodes from Prim cells   !
     !-----------------------------------------!
-    do c = -Prim % n_bnd_cells, -1
-      if(cell_data(c) .ne. 0) then
+    do c_p = -Prim % n_bnd_cells, -1
+      if(prim_bnd_cell_flag_in_reg(c_p) .ne. 0) then
 
         ! Take the Prim cell's nodes (these are from Prim)
-        do i_nod = 1, Prim % cells_n_nodes(c)
-          n_p = Prim % cells_n(i_nod, c)
+        do i_nod = 1, Prim % cells_n_nodes(c_p)
+          n_p = Prim % cells_n(i_nod, c_p)
 
           ! Additional boundary face in the Dual grid
-          f_d  = curr_f_d + node_data(n_p)
-          Dual % faces_n_nodes(f_d) = Dual % faces_n_nodes(f_d) + 1
-          Dual % faces_n(Dual % faces_n_nodes(f_d), f_d) = cell_to_node(c)
+          s_d  = curr_s_d + prim_node_rank_in_reg(n_p)
+          Dual % faces_n_nodes(s_d) = Dual % faces_n_nodes(s_d) + 1
+          Dual % faces_n(Dual % faces_n_nodes(s_d), s_d) = cell_to_node(c_p)
 
           ! Additional boundary cell in the Dual grid
-          b_d  = curr_b_d - node_data(n_p)
+          b_d  = curr_b_d - prim_node_rank_in_reg(n_p)
           Dual % cells_n_nodes(b_d) = Dual % cells_n_nodes(b_d) + 1
           call Enlarge % Matrix_Int(Dual % cells_n,  &
                                     i=(/1,Dual % cells_n_nodes(b_d)/))
-          Dual % cells_n(Dual % cells_n_nodes(b_d), b_d) = cell_to_node(c)
+          Dual % cells_n(Dual % cells_n_nodes(b_d), b_d) = cell_to_node(c_p)
           Dual % region % at_cell(b_d) = bc
 
           ! Store node_to_face (for the next step, adding edges)
-          node_to_face(n_p) = f_d
+          node_to_face(n_p) = s_d
           node_to_cell(n_p) = b_d
 
           ! Store cells surrounding each face in the Dual grid ...
           ! ... which correspond to nodes in the Prim grid
-          Dual % faces_c(1, f_d) = n_p  ! link to cell inside
-          Dual % faces_c(2, f_d) = b_d  ! link to boundary cell
+          Dual % faces_c(1, s_d) = n_p  ! link to cell inside
+          Dual % faces_c(2, s_d) = b_d  ! link to boundary cell
         end do
 
       end if
     end do
 
     ! Update current number of Dual faces
-    curr_f_d = curr_f_d + dual_f_here
+    curr_s_d = curr_s_d + dual_f_here
     curr_b_d = curr_b_d - dual_f_here
 
     !---------------------------------------------------------!
     !   Add additional nodes to Dual's face from Prim edges   !
     !   Here we work on the faces already introduced above    !
     !---------------------------------------------------------!
-    do e = 1, Prim % n_edges
-      if(edge_data(e) .ne. 0) then
+    unused = Convert % N_Edges_In_Region(Prim, bc, prim_edge_flag_in_reg)
+
+    do e_p = 1, Prim % n_edges
+      if(prim_edge_flag_in_reg(e_p) .ne. 0) then
 
         ! Take the Prim edge's nodes (these are from Prim)
         do i_nod = 1, 2
-          n_p = Prim % edges_n(i_nod, e)
+          n_p = Prim % edges_n(i_nod, e_p)
 
           ! This node_to_face was stored in the previous step
-          f_d = node_to_face(n_p)
-          Dual % faces_n_nodes(f_d) = Dual % faces_n_nodes(f_d) + 1
+          s_d = node_to_face(n_p)
+          Dual % faces_n_nodes(s_d) = Dual % faces_n_nodes(s_d) + 1
           call Enlarge % Matrix_Int(Dual % faces_n,  &
-                                    i=(/1,Dual % faces_n_nodes(f_d)/))
-          Dual % faces_n(Dual % faces_n_nodes(f_d), f_d) = edge_to_node(e)
+                                    i=(/1,Dual % faces_n_nodes(s_d)/))
+          Dual % faces_n(Dual % faces_n_nodes(s_d), s_d) = edge_to_node(e_p)
 
           ! This node_to_cell was stored in the previous step
           b_d = node_to_cell(n_p)
           Dual % cells_n_nodes(b_d) = Dual % cells_n_nodes(b_d) + 1
           call Enlarge % Matrix_Int(Dual % cells_n,  &
                                     i=(/1,Dual % cells_n_nodes(b_d)/))
-          Dual % cells_n(Dual % cells_n_nodes(b_d), b_d) = edge_to_node(e)
+          Dual % cells_n(Dual % cells_n_nodes(b_d), b_d) = edge_to_node(e_p)
         end do  ! i_nod for edge, goes from 1 to 2
 
       end if
@@ -469,29 +541,30 @@
     !   Add additional nodes to Dual's face from sharp corners   !
     !    Here we work on the faces already introduced before     !
     !------------------------------------------------------------!
-    do e = 1, Prim % n_edges
-      if(edge_data(e) .ne. 0) then
+    issue_warning = .false.
+    do e_p = 1, Prim % n_edges
+      if(prim_edge_flag_in_reg(e_p) .ne. 0) then
 
         do i_nod = 1, 2
-          n_p = Prim % edges_n(i_nod, e)
-          f_d = node_to_face(n_p)
+          n_p = Prim % edges_n(i_nod, e_p)
+          s_d = node_to_face(n_p)
           b_d = node_to_cell(n_p)
 
           ! The grid has sharp corners, add them to boundary faces and cells
-          if(sharp_corner(n_p) .gt. 0) then
-            if(sharp_inject(f_d) .eq. 0) then
+          if(prim_sharp_node_rank(n_p) .gt. 0) then
+            if(sharp_inject(s_d) .eq. 0) then
 
               ! Estimate the number of new node in Dual
-              ! (sharp_corner holds its local number)
-              n_d = Dual % n_nodes - sharp_corner(n_p) + 1
+              ! (prim_sharp_node_rank holds its local number)
+              n_d = Dual % n_nodes - prim_sharp_node_rank(n_p) + 1
               Dual % xn(n_d) = Prim % xn(n_p)
               Dual % yn(n_d) = Prim % yn(n_p)
               Dual % zn(n_d) = Prim % zn(n_p)
 
-              Dual % faces_n_nodes(f_d) = Dual % faces_n_nodes(f_d) + 1
+              Dual % faces_n_nodes(s_d) = Dual % faces_n_nodes(s_d) + 1
               call Enlarge % Matrix_Int(Dual % faces_n,  &
-                                        i=(/1,Dual % faces_n_nodes(f_d)/))
-              Dual % faces_n(Dual % faces_n_nodes(f_d), f_d) = n_d
+                                        i=(/1,Dual % faces_n_nodes(s_d)/))
+              Dual % faces_n(Dual % faces_n_nodes(s_d), s_d) = n_d
 
               Dual % cells_n_nodes(b_d) = Dual % cells_n_nodes(b_d) + 1
               call Enlarge % Matrix_Int(Dual % cells_n,  &
@@ -499,37 +572,46 @@
               Dual % cells_n(Dual % cells_n_nodes(b_d), b_d) = n_d
 
               ! Mark that the face has been injected a sharp corner
-              ! write(*,'(a,i9)') ' # Injecting new node in face', f_d
-              sharp_inject(f_d) = sharp_inject(f_d) + 1
+              ! write(*,'(a,i9)') ' # Injecting new node in face', s_d
+              sharp_inject(s_d) = sharp_inject(s_d) + 1
 
               ! Check those little nodes inserted just before
-              n1 = Dual % faces_n(Dual % faces_n_nodes(f_d)-2, f_d)
-              n2 = Dual % faces_n(Dual % faces_n_nodes(f_d)-1, f_d)
+              n1_d = Dual % faces_n(Dual % faces_n_nodes(s_d)-2, s_d)
+              n2_d = Dual % faces_n(Dual % faces_n_nodes(s_d)-1, s_d)
               if(concave_link(1,n_d) .eq. 0 .and.  &
                  concave_link(2,n_d) .eq. 0) then
-                concave_link(1,n_d) = n1
-                concave_link(2,n_d) = n2
+                concave_link(1,n_d) = n1_d
+                concave_link(2,n_d) = n2_d
               else
-                print *, '# Well, you didn''t see this coming!'
-                print *, '# One sharp corner can be in more than one edge'
+                issue_warning = .true.
               end if
 
-            end if  ! sharp inject in f_d
+            end if  ! sharp inject in s_d
           end if    ! sharp corner here
 
         end do  ! i_nod for edge, goes from 1 to 2
-      end if
-    end do  ! through edges
+      end if    ! edge is in the region
+    end do      ! through edges
 
-  end do
+    if(issue_warning) then
+      print *, '# Well, you didn''t see this coming!'
+      print *, '# One sharp corner can be in more than one edge'
+    end if
+
+  end do  ! bc, boundary region
+
+  ! De-allocate what you won't need any more
+  deallocate(cell_to_node)
+  deallocate(node_to_face)
+  deallocate(node_to_cell)
 
   !---------------------------------------!
   !                                       !
   !   Sort the points on boundary faces   !
   !                                       !
   !---------------------------------------!
-  do s = Prim % n_edges + 1, Dual % n_faces
-    call Convert % Sort_Face_Nodes(Dual, s, concave_link)
+  do s_d = Prim % n_edges + 1, Dual % n_faces
+    call Convert % Sort_Face_Nodes(Dual, s_d, concave_link)
   end do
 
   !------------------------------------------------------------!
@@ -552,46 +634,46 @@
   !   Store cells' faces and nodes   !
   !                                  !
   !----------------------------------!
-  do s = 1, Dual % n_faces
-    c1 = Dual % faces_c(1, s)
-    c2 = Dual % faces_c(2, s)
+  do s_d = 1, Dual % n_faces
+    c1_d = Dual % faces_c(1, s_d)
+    c2_d = Dual % faces_c(2, s_d)
 
     !----------------------------------------------------!
     !   Store faces surrounding each cell in Dual grid   !
     !----------------------------------------------------!
-    Dual % cells_n_faces(c1) = Dual % cells_n_faces(c1) + 1
-    Dual % cells_n_faces(c2) = Dual % cells_n_faces(c2) + 1
-    call Enlarge % Matrix_int(Dual % cells_f, i=(/1,Dual % cells_n_faces(c1)/))
-    call Enlarge % Matrix_int(Dual % cells_f, i=(/1,Dual % cells_n_faces(c2)/))
-    Dual % cells_f(Dual % cells_n_faces(c1), c1) = s
-    Dual % cells_f(Dual % cells_n_faces(c2), c2) = s
+    Dual % cells_n_faces(c1_d) = Dual % cells_n_faces(c1_d) + 1
+    Dual % cells_n_faces(c2_d) = Dual % cells_n_faces(c2_d) + 1
+    call Enlarge % Matrix_int(Dual % cells_f,i=(/1,Dual % cells_n_faces(c1_d)/))
+    call Enlarge % Matrix_int(Dual % cells_f,i=(/1,Dual % cells_n_faces(c2_d)/))
+    Dual % cells_f(Dual % cells_n_faces(c1_d), c1_d) = s_d
+    Dual % cells_f(Dual % cells_n_faces(c2_d), c2_d) = s_d
 
     !----------------------------------------------------!
     !   Store nodes surrounding each cell in Dual grid   !
     !----------------------------------------------------!
-    do i_nod = 1, Dual % faces_n_nodes(s)
-      n = Dual % faces_n(i_nod, s)
+    do i_nod = 1, Dual % faces_n_nodes(s_d)
+      n_d = Dual % faces_n(i_nod, s_d)
 
       ! Handle cell 1
-      do j_nod = 1, Dual % cells_n_nodes(c1)
-        n1 = Dual % cells_n(j_nod, c1)
-        if(n1 .eq. n) goto 1
+      do j_nod = 1, Dual % cells_n_nodes(c1_d)
+        n1_d = Dual % cells_n(j_nod, c1_d)
+        if(n1_d .eq. n_d) goto 1
       end do  ! j_nod
-      Dual % cells_n_nodes(c1) = Dual % cells_n_nodes(c1) + 1
+      Dual % cells_n_nodes(c1_d) = Dual % cells_n_nodes(c1_d) + 1
       call Enlarge % Matrix_Int(Dual % cells_n,  &
-                                i=(/1,Dual % cells_n_nodes(c1)/))
-      Dual % cells_n(Dual % cells_n_nodes(c1), c1) = n
+                                i=(/1,Dual % cells_n_nodes(c1_d)/))
+      Dual % cells_n(Dual % cells_n_nodes(c1_d), c1_d) = n_d
 1     continue
 
       ! Handle cell 2
-      do j_nod = 1, Dual % cells_n_nodes(c2)
-        n2 = Dual % cells_n(j_nod, c2)
-        if(n2 .eq. n) goto 2
+      do j_nod = 1, Dual % cells_n_nodes(c2_d)
+        n2_d = Dual % cells_n(j_nod, c2_d)
+        if(n2_d .eq. n_d) goto 2
       end do  ! j_nod
-      Dual % cells_n_nodes(c2) = Dual % cells_n_nodes(c2) + 1
+      Dual % cells_n_nodes(c2_d) = Dual % cells_n_nodes(c2_d) + 1
       call Enlarge % Matrix_Int(Dual % cells_n,  &
-                                i=(/1,Dual % cells_n_nodes(c2)/))
-      Dual % cells_n(Dual % cells_n_nodes(c2), c2) = n
+                                i=(/1,Dual % cells_n_nodes(c2_d)/))
+      Dual % cells_n(Dual % cells_n_nodes(c2_d), c2_d) = n_d
 2     continue
 
     end do  ! do i_nod
@@ -603,9 +685,155 @@
   !   Fix the number of nodes for polyhedral (all) cells   !
   !                                                        !
   !--------------------------------------------------------!
-  do c = 1, Dual % n_cells
-    call Sort % Int_Array(Dual % cells_n(1:Dual % cells_n_nodes(c),c))
-    Dual % cells_n_nodes(c) = -Dual % cells_n_nodes(c)
+  do c_d = 1, Dual % n_cells
+    call Sort % Int_Array(Dual % cells_n(1:Dual % cells_n_nodes(c_d),c_d))
+    Dual % cells_n_nodes(c_d) = -Dual % cells_n_nodes(c_d)
+    Assert(Dual % cells_n_nodes(c_d) .lt. 0)
+  end do
+
+  !------------------------!
+  !                        !
+  !   Mark concave cells   !
+  !                        !
+  !- - - - - - - - - - - - +---------------------------------------------!
+  !   Please note that Prim node -> Dual cell works directly because I   !
+  !   preserved the numbering.                                           !
+  !                                                                      !
+  !   However, Prim cell ->  Dual node would not work directly because   !
+  !   dual nodes are shifted by boundary nodes and mixed with extra      !
+  !   sharp-feature nodes.  (Think about it a bit more and try to        !
+  !   explain it in simpler words.)                                      !
+  !----------------------------------------------------------------------!
+  do e_p = 1, Prim % n_edges
+    if(prim_sharp_edge_flag(e_p) .lt. 0) then
+      c1_d = Prim % edges_n(1, e_p)   ! nodes(Prim) =--> cells(Dual)
+      c2_d = Prim % edges_n(2, e_p)   ! nodes(Prim) =--> cells(Dual)
+      Assert(c1_d .le. Dual % n_cells)
+      Assert(c2_d .le. Dual % n_cells)
+      Dual % concave(c1_d) = .true.
+      Dual % concave(c2_d) = .true.
+    end if
+  end do
+
+  ! Allocate memory for helping array
+  allocate(prim_node_n_norms(Prim % n_nodes));  prim_node_n_norms(:) = 0
+
+  !-----------------------------------------------------------------------!
+  !                                                                       !
+  !   For each "concave" Prim node, find characterstic boundary normals   !
+  !                                                                       !
+  !-----------------------------------------------------------------------!
+  do s_p = 1, Prim % n_faces
+    c1_p = Prim % faces_c(1, s_p)
+    c2_p = Prim % faces_c(2, s_p)
+    if(c2_p .lt. 0) then
+      do i_nod = 1, Prim % faces_n_nodes(s_p)
+        n_p = Prim % faces_n(i_nod, s_p)
+        c_d = n_p  ! nodes(Prim) =--> cells(Dual)
+        if(Dual % concave(c_d)) then
+
+          ! Surface magnitude is not yet computed at this point
+          Prim % s(s_p) = sqrt(  Prim % sx(s_p) ** 2  &
+                               + Prim % sy(s_p) ** 2  &
+                               + Prim % sz(s_p) ** 2)
+          nx = Prim % sx(s_p) / Prim % s(s_p)
+          ny = Prim % sy(s_p) / Prim % s(s_p)
+          nz = Prim % sz(s_p) / Prim % s(s_p)
+
+          nn = prim_node_n_norms(n_p)
+
+          !---------------------------------------------!
+          !   If no normals have been found/saved yet   !
+          !---------------------------------------------!
+          if(nn .eq. 0) then
+
+            prim_node_n_norms(n_p) = 1  ! first normal
+            call Enlarge % Matrix_Real(prim_node_dx,  &
+                                       i=(/1,1/),     &
+                                       j=(/1,Prim % n_nodes/))
+            call Enlarge % Matrix_Real(prim_node_dy,  &
+                                       i=(/1,1/),     &
+                                       j=(/1,Prim % n_nodes/))
+            call Enlarge % Matrix_Real(prim_node_dz,  &
+                                       i=(/1,1/),     &
+                                       j=(/1,Prim % n_nodes/))
+            call Enlarge % Matrix_Real(prim_node_d,   &
+                                       i=(/1,1/),     &
+                                       j=(/1,Prim % n_nodes/))
+            prim_node_dx(1, n_p) = nx
+            prim_node_dy(1, n_p) = ny
+            prim_node_dz(1, n_p) = nz
+            prim_node_d (1, n_p) = sqrt(Prim % s(s_p))  ! measure of length
+
+          !----------------------------------------------------!
+          !   Some normals have been already found and saved   !
+          !----------------------------------------------------!
+          else
+
+            ! Check if this normal has been stored already
+            found = .false.
+            do i_nor = 1, nn  ! browse through stored normals
+              if(Math % Approx_Real(nx, prim_node_dx(i_nor, n_p), MICRO) .and. &
+                 Math % Approx_Real(ny, prim_node_dy(i_nor, n_p), MICRO) .and. &
+                 Math % Approx_Real(nz, prim_node_dz(i_nor, n_p), MICRO)) then
+                found = .true.
+              end if
+            end do
+
+            ! If not found, store one more normal
+            if(.not. found) then
+              prim_node_n_norms(n_p) = prim_node_n_norms(n_p) + 1
+              nn = prim_node_n_norms(n_p)
+              call Enlarge % Matrix_Real(prim_node_dx,  &
+                                         i=(/1,nn/),     &
+                                         j=(/1,Prim % n_nodes/))
+              call Enlarge % Matrix_Real(prim_node_dy,  &
+                                         i=(/1,nn/),     &
+                                         j=(/1,Prim % n_nodes/))
+              call Enlarge % Matrix_Real(prim_node_dz,  &
+                                         i=(/1,nn/),     &
+                                         j=(/1,Prim % n_nodes/))
+              call Enlarge % Matrix_Real(prim_node_d,   &
+                                         i=(/1,1/),     &
+                                         j=(/1,Prim % n_nodes/))
+              prim_node_dx(nn, n_p) = nx
+              prim_node_dy(nn, n_p) = ny
+              prim_node_dz(nn, n_p) = nz
+              prim_node_d (nn, n_p) = sqrt(Prim % s(s_p))  ! measure of length
+            end if
+          end if
+        end if
+      end do
+    end if
+  end do
+
+  do c_d = 1, Dual % n_cells
+    if(Dual % concave(c_d)) then
+      n_p = c_d  ! nodes(Prim) =--> cells(Dual)
+
+      ! First find characteristic shift
+      delta = 0
+      do i_nor = 1, prim_node_n_norms(n_p)
+        delta = delta + prim_node_d(i_nor, n_p)
+      end do
+      delta = delta / prim_node_n_norms(n_p)
+      delta = delta * 0.2  ! the 0.2 is an ad-hoc guess
+
+      ! Just copy the coordinates of the Prim node ...
+      Dual % xc(c_d) = Prim % xn(n_p)
+      Dual % yc(c_d) = Prim % yn(n_p)
+      Dual % zc(c_d) = Prim % zn(n_p)
+
+      ! .. then shift it according to normals
+      do i_nor = 1, prim_node_n_norms(n_p)
+        Dual % xc(c_d) = Dual % xc(c_d) - prim_node_dx(i_nor, n_p) * delta
+        Dual % yc(c_d) = Dual % yc(c_d) - prim_node_dy(i_nor, n_p) * delta
+        Dual % zc(c_d) = Dual % zc(c_d) - prim_node_dz(i_nor, n_p) * delta
+      end do
+      if(DEBUG) then
+        call Dual % Save_Vtk_Cell(c_d, "concave_cell", c_d)
+      end if
+    end if
   end do
 
   end subroutine

--- a/Sources/Convert/Convert_Mod/N_Bnd_Cells_In_Region.f90
+++ b/Sources/Convert/Convert_Mod/N_Bnd_Cells_In_Region.f90
@@ -1,5 +1,5 @@
 !==============================================================================!
-  integer function N_Bnd_Cells_In_Region(Convert, Grid, bc, cell_data)
+  integer function N_Bnd_Cells_In_Region(Convert, Grid, bc, bnd_cell_flag)
 !------------------------------------------------------------------------------!
 !>  Counts and marks boundary cells in a specified boundary condition (bc)
 !>  category within a grid.
@@ -9,9 +9,9 @@
   class(Convert_Type) :: Convert  !! parent class
   type(Grid_Type)     :: Grid     !! grid being converted
   integer             :: bc       !! boundary condition rank (number)
-  integer             :: cell_data(-Grid % n_bnd_cells  &
-                                   :Grid % n_cells)  !! stored data on
-                                                     !! boundary cells
+  integer             :: bnd_cell_flag(-Grid % n_bnd_cells  &
+                                       :Grid % n_cells)  !! stored flag on
+                                                         !! boundary cells
 !-----------------------------------[Locals]-----------------------------------!
   integer :: c, cnt
 !------------------------[Avoid unused parent warning]-------------------------!
@@ -19,13 +19,13 @@
 !==============================================================================!
 
   ! Nullify on entry
-  cnt = 0
-  cell_data(:) = 0
+  bnd_cell_flag(:) = 0
 
+  cnt = 0
   do c = -Grid % n_bnd_cells, -1
     if( Grid % region % at_cell(c) .eq. bc ) then
       cnt = cnt + 1
-      cell_data(c) = cell_data(c) + 1
+      bnd_cell_flag(c) = bnd_cell_flag(c) + 1
     end if
   end do
 

--- a/Sources/Convert/Convert_Mod/N_Edges_In_Region.f90
+++ b/Sources/Convert/Convert_Mod/N_Edges_In_Region.f90
@@ -1,14 +1,14 @@
 !==============================================================================!
-  integer function N_Edges_In_Region(Convert, Grid, bc, edge_data)
+  integer function N_Edges_In_Region(Convert, Grid, bc, edge_flag)
 !------------------------------------------------------------------------------!
-!   Counts and marks (with edge_data) edges in the given boundary color        !
+!   Counts and marks (with edge_flag) edges in the given boundary color        !
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert
   type(Grid_Type)     :: Grid
   integer             :: bc
-  integer             :: edge_data(Grid % n_edges)
+  integer             :: edge_flag(Grid % n_edges)
 !-----------------------------------[Locals]-----------------------------------!
   integer :: e, cnt, s1, s2, n1, n2
   real    :: norm_1(3), norm_2(3)
@@ -20,7 +20,7 @@
 
   ! Nullify on entry
   cnt = 0
-  edge_data(:) = 0
+  edge_flag(:) = 0
 
   !---------------------------------------------!
   !                                             !
@@ -51,7 +51,7 @@
       !   Edge is not sharp, mark it as zero   !
       !----------------------------------------!
       if(dot_product(norm_1, norm_2) >= 0.7071) then
-        edge_data(e) = 0
+        edge_flag(e) = 0
 
       !--------------------------------------------------!
       !   Edge is geometrically sharp, still check if    !
@@ -81,12 +81,12 @@
         ! Edge is convex
         if(dot_product(vec_ef(1:3), norm_1(1:3)) < 0.0 .and.  &
            dot_product(vec_ef(1:3), norm_2(1:3)) < 0.0) then
-          edge_data(e) = 1
+          edge_flag(e) = 1
 
         ! Edge is concave
         else if(dot_product(vec_ef(1:3), norm_1(1:3)) > 0.0 .and.  &
                 dot_product(vec_ef(1:3), norm_2(1:3)) > 0.0) then
-          edge_data(e) = -1
+          edge_flag(e) = -1
 
         else
           print '(A,99F12.3)', 'BAD', norm2(vec_ef(1:3)), norm_1, norm_2,  &
@@ -109,9 +109,9 @@
   do e = 1, Grid % n_edges
     if(Grid % edges_bc(bc, e) .gt. 0) then
     if( sum(Grid % edges_bc(1:Grid % n_bnd_regions, e)) .gt. 1 ) then
-      if(edge_data(e) .eq. 0) then  ! hasn't been marked yet
+      if(edge_flag(e) .eq. 0) then  ! hasn't been marked yet
         cnt = cnt + 1
-        edge_data(e) = 1
+        edge_flag(e) = 1
       end if
     end if
     end if  ! it is in this bc

--- a/Sources/Convert/Convert_Mod/N_Nodes_At_Boundary.f90
+++ b/Sources/Convert/Convert_Mod/N_Nodes_At_Boundary.f90
@@ -7,7 +7,6 @@
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert  !! parent class
   type(Grid_Type)     :: Grid     !! grid being converted
-  integer             :: bc       !! boundary condition rank (number)
   integer             :: node_flag_at_boundary(Grid % n_nodes)
 !-----------------------------------[Locals]-----------------------------------!
   integer :: c, i_nod, n, cnt

--- a/Sources/Convert/Convert_Mod/N_Nodes_At_Boundary.f90
+++ b/Sources/Convert/Convert_Mod/N_Nodes_At_Boundary.f90
@@ -1,15 +1,14 @@
 !==============================================================================!
-  integer function N_Nodes_In_Region(Convert, Grid, bc, node_rank_in_region)
+  integer function N_Nodes_At_Boundary(Convert, Grid, node_flag_at_boundary)
 !------------------------------------------------------------------------------!
-!>  Counts and marks nodes associated with a specific boundary condition
-!>  within a grid.
+!>  Counts and marks nodes associated with all boundarues.
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert  !! parent class
   type(Grid_Type)     :: Grid     !! grid being converted
   integer             :: bc       !! boundary condition rank (number)
-  integer             :: node_rank_in_region(Grid % n_nodes)
+  integer             :: node_flag_at_boundary(Grid % n_nodes)
 !-----------------------------------[Locals]-----------------------------------!
   integer :: c, i_nod, n, cnt
 !------------------------[Avoid unused parent warning]-------------------------!
@@ -18,24 +17,22 @@
 
   ! Nullify on entry
   cnt = 0
-  node_rank_in_region(:) = 0
+  node_flag_at_boundary(:) = 0
 
   ! Browse through all boundary cells and mark nodes
   ! of those cells in the given boundary condition
   do c = -Grid % n_bnd_cells, -1
-    if( Grid % region % at_cell(c) .eq. bc ) then
-      do i_nod = 1, Grid % cells_n_nodes(c)
-        n = Grid % cells_n(i_nod, c)
-        if(node_rank_in_region(n) .eq. 0) then  ! hasn't been marked yet
-          cnt = cnt + 1
-          node_rank_in_region(n) = cnt
-        end if
-      end do
-    end if
+    do i_nod = 1, Grid % cells_n_nodes(c)
+      n = Grid % cells_n(i_nod, c)
+      if(node_flag_at_boundary(n) .eq. 0) then  ! hasn't been marked yet
+        cnt = cnt + 1
+        node_flag_at_boundary(n) = 1
+      end if
+    end do
   end do
 
   ! Return a sum of all marked nodes
-  N_Nodes_In_Region = cnt
+  N_Nodes_At_Boundary = cnt
 
   end function
 

--- a/Sources/Convert/Convert_Mod/N_Sharp_Corners.f90
+++ b/Sources/Convert/Convert_Mod/N_Sharp_Corners.f90
@@ -1,76 +1,41 @@
 !==============================================================================!
-  integer function N_Sharp_Corners(Convert, Grid, sharp_node_sharp_node_rank)
+  integer function N_Sharp_Corners(Convert, Grid,  &
+                                   sharp_edge_flag, sharp_node_rank)
 !------------------------------------------------------------------------------!
 !>  This function is designed to identify and count sharp corners in a 3D
 !>  grid structure. It takes the Grid as an input and returns an array
-!>  sharp_node_sharp_node_rank marking the nodes at sharp corners.
-!------------------------------------------------------------------------------!
-!   Functionality                                                              !
-!                                                                              !
-!   * Initialization: The function initializes a counter cnt and sets all      !
-!     entries in the sharp_node_sharp_node_rank array to zero.                 !
-!   * Identifying Sharp Corners:                                               !
-!     - Iterates over each edge in the grid.                                   !
-!     - For edges between two boundary faces, it computes the normals of these !
-!       faces.                                                                 !
-!     - If the angle between these normals is less than 45 degrees (indicating !
-!       a sharp corner), the nodes at either end of the edge are marked in     !
-!       sharp_node_sharp_node_rank by incrementing their respective counts.    !
-!   * Counting Sharp Corners:                                                  !
-!     - After marking, it counts the number of nodes that have been marked     !
-!       more than twice, indicating a sharp corner.                            !
-!     - The count is updated in the sharp_node_sharp_node_rank array,          !
-!       while nodes not part of a sharp corner are reset to zero.              !
-!   * Return Value:                                                            !
-!     - The function returns the total count of sharp corner nodes.            !
+!>  sharp_node_rank marking the nodes at sharp corners.
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
-  class(Convert_Type) :: Convert
-  type(Grid_Type)     :: Grid
-  integer             :: sharp_node_sharp_node_rank(Grid % n_nodes)
+  class(Convert_Type)  :: Convert
+  type(Grid_Type)      :: Grid
+  integer, intent(in)  :: sharp_edge_flag(Grid % n_edges)
+  integer, intent(out) :: sharp_node_rank(Grid % n_nodes)
 !-----------------------------------[Locals]-----------------------------------!
-  integer :: e, cnt, s1, s2, n1, n2, n
-  real    :: norm_1(3), norm_2(3)
+  integer :: e, cnt, n1, n2, n
 !------------------------[Avoid unused parent warning]-------------------------!
   Unused(Convert)
 !==============================================================================!
 
   ! Nullify on entry
-  sharp_node_sharp_node_rank(:) = 0
+  sharp_node_rank(:) = 0
 
-  !---------------------------------------------!
-  !   Fetch geometrically sharp edges (first)   !
-  !---------------------------------------------!
+  !------------------------------------------!
+  !   Assign marks to nodes at sharp edges   !
+  !------------------------------------------!
   do e = 1, Grid % n_edges
 
-    ! If edge is in-between two boundary faces
-    ! (yes, Grid % edges_f stores only boundary faces, very bad name choice)
-    if(Grid % edges_fb(1, e) .ne. 0 .and.  &
-       Grid % edges_fb(2, e) .ne. 0) then
+    ! If it is sharp, both convex (+1) and concave (-1)
+    if(sharp_edge_flag(e) .ne. 0) then
 
-      ! Take the boundary faces around the edge
-      s1 = Grid % edges_fb(1, e)
-      s2 = Grid % edges_fb(2, e)
+      ! Take edges' nodes and mark them (increase
+      ! the number of times they have been visited)
+      n1 = Grid % edges_n(1, e)
+      n2 = Grid % edges_n(2, e)
 
-      ! Compute normals of the two faces surrounding the edge
-      norm_1(1) = Grid % sx(s1);  norm_2(1) = Grid % sx(s2)
-      norm_1(2) = Grid % sy(s1);  norm_2(2) = Grid % sy(s2)
-      norm_1(3) = Grid % sz(s1);  norm_2(3) = Grid % sz(s2)
-      norm_1(1:3) = norm_1(1:3) / norm2(norm_1(1:3))
-      norm_2(1:3) = norm_2(1:3) / norm2(norm_2(1:3))
-
-      ! If angle is less than 45 (135) degrees, or is simply sharp
-      if(dot_product(norm_1(1:3), norm_2(1:3)) < 0.7071) then
-
-        ! Take edges' nodes and mark them (increase
-        ! the number of times they have been visited)
-        n1 = Grid % edges_n(1, e)
-        n2 = Grid % edges_n(2, e)
-
-        sharp_node_sharp_node_rank(n1) = sharp_node_sharp_node_rank(n1) + 1
-        sharp_node_sharp_node_rank(n2) = sharp_node_sharp_node_rank(n2) + 1
-      end if
+      sharp_node_rank(n1) = sharp_node_rank(n1) + 1
+      sharp_node_rank(n2) = sharp_node_rank(n2) + 1
     end if
 
   end do
@@ -80,11 +45,11 @@
   !----------------------------------------------------------------------!
   cnt = 0
   do n = 1, Grid % n_nodes
-    if(sharp_node_sharp_node_rank(n) .gt. 2) then
+    if(sharp_node_rank(n) .gt. 2) then
       cnt = cnt + 1
-      sharp_node_sharp_node_rank(n) = cnt
+      sharp_node_rank(n) = cnt
     else
-      sharp_node_sharp_node_rank(n) = 0
+      sharp_node_rank(n) = 0
     end if
   end do
 

--- a/Sources/Convert/Convert_Mod/N_Sharp_Corners.f90
+++ b/Sources/Convert/Convert_Mod/N_Sharp_Corners.f90
@@ -1,26 +1,26 @@
 !==============================================================================!
-  integer function N_Sharp_Corners(Convert, Grid, sharp_corner)
+  integer function N_Sharp_Corners(Convert, Grid, sharp_node_sharp_node_rank)
 !------------------------------------------------------------------------------!
 !>  This function is designed to identify and count sharp corners in a 3D
 !>  grid structure. It takes the Grid as an input and returns an array
-!>  sharp_corner marking the nodes at sharp corners.
+!>  sharp_node_sharp_node_rank marking the nodes at sharp corners.
 !------------------------------------------------------------------------------!
 !   Functionality                                                              !
 !                                                                              !
 !   * Initialization: The function initializes a counter cnt and sets all      !
-!     entries in the sharp_corner array to zero.                               !
+!     entries in the sharp_node_sharp_node_rank array to zero.                 !
 !   * Identifying Sharp Corners:                                               !
 !     - Iterates over each edge in the grid.                                   !
 !     - For edges between two boundary faces, it computes the normals of these !
 !       faces.                                                                 !
 !     - If the angle between these normals is less than 45 degrees (indicating !
 !       a sharp corner), the nodes at either end of the edge are marked in     !
-!       sharp_corner by incrementing their respective counts.                  !
+!       sharp_node_sharp_node_rank by incrementing their respective counts.    !
 !   * Counting Sharp Corners:                                                  !
 !     - After marking, it counts the number of nodes that have been marked     !
 !       more than twice, indicating a sharp corner.                            !
-!     - The count is updated in the sharp_corner array, while nodes not part   !
-!       of a sharp corner are reset to zero.                                   !
+!     - The count is updated in the sharp_node_sharp_node_rank array,          !
+!       while nodes not part of a sharp corner are reset to zero.              !
 !   * Return Value:                                                            !
 !     - The function returns the total count of sharp corner nodes.            !
 !------------------------------------------------------------------------------!
@@ -28,7 +28,7 @@
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert
   type(Grid_Type)     :: Grid
-  integer             :: sharp_corner(Grid % n_nodes)
+  integer             :: sharp_node_sharp_node_rank(Grid % n_nodes)
 !-----------------------------------[Locals]-----------------------------------!
   integer :: e, cnt, s1, s2, n1, n2, n
   real    :: norm_1(3), norm_2(3)
@@ -37,8 +37,7 @@
 !==============================================================================!
 
   ! Nullify on entry
-  cnt             = 0
-  sharp_corner(:) = 0
+  sharp_node_sharp_node_rank(:) = 0
 
   !---------------------------------------------!
   !   Fetch geometrically sharp edges (first)   !
@@ -69,22 +68,23 @@
         n1 = Grid % edges_n(1, e)
         n2 = Grid % edges_n(2, e)
 
-        sharp_corner(n1) = sharp_corner(n1) + 1
-        sharp_corner(n2) = sharp_corner(n2) + 1
+        sharp_node_sharp_node_rank(n1) = sharp_node_sharp_node_rank(n1) + 1
+        sharp_node_sharp_node_rank(n2) = sharp_node_sharp_node_rank(n2) + 1
       end if
     end if
 
   end do
 
-  !------------------------------------------------------------!
-  !   Count nodes which have been marked more than two times   !
-  !------------------------------------------------------------!
+  !----------------------------------------------------------------------!
+  !   Assign ranks to nodes which have been marked more than two times   !
+  !----------------------------------------------------------------------!
+  cnt = 0
   do n = 1, Grid % n_nodes
-    if(sharp_corner(n) > 2) then
+    if(sharp_node_sharp_node_rank(n) .gt. 2) then
       cnt = cnt + 1
-      sharp_corner(n) = cnt
+      sharp_node_sharp_node_rank(n) = cnt
     else
-      sharp_corner(n) = 0
+      sharp_node_sharp_node_rank(n) = 0
     end if
   end do
 

--- a/Sources/Convert/Convert_Mod/N_Sharp_Edges.f90
+++ b/Sources/Convert/Convert_Mod/N_Sharp_Edges.f90
@@ -1,31 +1,32 @@
 !==============================================================================!
-  integer function N_Sharp_Edges(Convert, Grid, edge_flag)
+  integer function N_Sharp_Edges(Convert, Grid, sharp_edge_flag)
 !------------------------------------------------------------------------------!
 !>  Aims to identify and count sharp edges in the grid, which are either
 !>  geometrically sharp or located between different boundary conditions.
 !------------------------------------------------------------------------------!
 !   Functionality                                                              !
 !                                                                              !
-!   * Initialization: Initializes a counter cnt and sets the edge_flag array   !
+!   * Initialization:                                                          !
+!     - Initializes a counter cnt and sets the sharp_edge_flag array           !
 !   * Identifying Geometrically Sharp Edges:                                   !
 !     - Iterates through each edge, focusing on those between two boundary     !
 !       faces.                                                                 !
 !     - Computes face normals and checks if the edge is geometrically sharp    !
 !       (based on the angle between normals).                                  !
-!     - Marks edges as convex, concave, or not sharp in the edge_flag array    !
-!       based on their geometric relation with adjacent faces.                 !
+!     - Marks edges as convex, concave, or not sharp in the sharp_edge_flag    !
+!       array based on their geometric relation with adjacent faces.           !
 !   * Edges Between Different Boundary Conditions:                             !
 !     - Additionally, it checks if an edge lies between faces with different   !
-!       boundary conditions.
-!     - Such edges are also marked as sharp if not already done.
-!   * Return Value:
-!     - Returns the total count of sharp edges.
+!       boundary conditions.                                                   !
+!     - Such edges are also marked as sharp if not already done.               !
+!   * Return Value:                                                            !
+!     - Returns the total count of sharp edges.                                !
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
-  class(Convert_Type) :: Convert                    !! parent class
-  type(Grid_Type)     :: Grid                       !! grid being converted
-  integer             :: edge_flag(Grid % n_edges)  !! edge data
+  class(Convert_Type)  :: Convert                    !! parent class
+  type(Grid_Type)      :: Grid                       !! grid being converted
+  integer, intent(out) :: sharp_edge_flag(Grid % n_edges)  !! edge data
 !-----------------------------------[Locals]-----------------------------------!
   integer :: e, cnt, s1, s2, n1, n2
   real    :: norm_1(3), norm_2(3)
@@ -37,7 +38,7 @@
 
   ! Nullify on entry
   cnt = 0
-  edge_flag(:) = 0
+  sharp_edge_flag(:) = 0
 
   !---------------------------------------------!
   !                                             !
@@ -68,7 +69,7 @@
       !   Edge is not sharp, mark it as zero   !
       !----------------------------------------!
       if(dot_product(norm_1, norm_2) >= 0.7071) then
-        edge_flag(e) = 0
+        sharp_edge_flag(e) = 0
 
       !--------------------------------------------------!
       !   Edge is geometrically sharp, still check if    !
@@ -98,12 +99,12 @@
         ! Edge is convex
         if(dot_product(vec_ef(1:3), norm_1(1:3)) < 0.0 .and.  &
            dot_product(vec_ef(1:3), norm_2(1:3)) < 0.0) then
-          edge_flag(e) = 1
+          sharp_edge_flag(e) = 1
 
         ! Edge is concave
         else if(dot_product(vec_ef(1:3), norm_1(1:3)) > 0.0 .and.  &
                 dot_product(vec_ef(1:3), norm_2(1:3)) > 0.0) then
-          edge_flag(e) = -1
+          sharp_edge_flag(e) = -1
 
         else
           print '(a,99f12.3)', 'BAD', norm2(vec_ef(1:3)),       &
@@ -126,9 +127,9 @@
   !-------------------------------------------------------------------!
   do e = 1, Grid % n_edges
     if( sum(Grid % edges_bc(1:Grid % n_bnd_regions, e)) .gt. 1 ) then
-      if(edge_flag(e) .eq. 0) then  ! hasn't been marked yet
+      if(sharp_edge_flag(e) .eq. 0) then  ! hasn't been marked yet
         cnt = cnt + 1
-        edge_flag(e) = 1
+        sharp_edge_flag(e) = 1
       end if
     end if
   end do

--- a/Sources/Convert/Convert_Mod/N_Sharp_Edges.f90
+++ b/Sources/Convert/Convert_Mod/N_Sharp_Edges.f90
@@ -1,18 +1,18 @@
 !==============================================================================!
-  integer function N_Sharp_Edges(Convert, Grid, edge_data)
+  integer function N_Sharp_Edges(Convert, Grid, edge_flag)
 !------------------------------------------------------------------------------!
 !>  Aims to identify and count sharp edges in the grid, which are either
 !>  geometrically sharp or located between different boundary conditions.
 !------------------------------------------------------------------------------!
 !   Functionality                                                              !
 !                                                                              !
-!   * Initialization: Initializes a counter cnt and sets the edge_data array   !
+!   * Initialization: Initializes a counter cnt and sets the edge_flag array   !
 !   * Identifying Geometrically Sharp Edges:                                   !
 !     - Iterates through each edge, focusing on those between two boundary     !
 !       faces.                                                                 !
 !     - Computes face normals and checks if the edge is geometrically sharp    !
 !       (based on the angle between normals).                                  !
-!     - Marks edges as convex, concave, or not sharp in the edge_data array    !
+!     - Marks edges as convex, concave, or not sharp in the edge_flag array    !
 !       based on their geometric relation with adjacent faces.                 !
 !   * Edges Between Different Boundary Conditions:                             !
 !     - Additionally, it checks if an edge lies between faces with different   !
@@ -25,7 +25,7 @@
 !---------------------------------[Arguments]----------------------------------!
   class(Convert_Type) :: Convert                    !! parent class
   type(Grid_Type)     :: Grid                       !! grid being converted
-  integer             :: edge_data(Grid % n_edges)  !! edge data
+  integer             :: edge_flag(Grid % n_edges)  !! edge data
 !-----------------------------------[Locals]-----------------------------------!
   integer :: e, cnt, s1, s2, n1, n2
   real    :: norm_1(3), norm_2(3)
@@ -37,7 +37,7 @@
 
   ! Nullify on entry
   cnt = 0
-  edge_data(:) = 0
+  edge_flag(:) = 0
 
   !---------------------------------------------!
   !                                             !
@@ -68,7 +68,7 @@
       !   Edge is not sharp, mark it as zero   !
       !----------------------------------------!
       if(dot_product(norm_1, norm_2) >= 0.7071) then
-        edge_data(e) = 0
+        edge_flag(e) = 0
 
       !--------------------------------------------------!
       !   Edge is geometrically sharp, still check if    !
@@ -98,12 +98,12 @@
         ! Edge is convex
         if(dot_product(vec_ef(1:3), norm_1(1:3)) < 0.0 .and.  &
            dot_product(vec_ef(1:3), norm_2(1:3)) < 0.0) then
-          edge_data(e) = 1
+          edge_flag(e) = 1
 
         ! Edge is concave
         else if(dot_product(vec_ef(1:3), norm_1(1:3)) > 0.0 .and.  &
                 dot_product(vec_ef(1:3), norm_2(1:3)) > 0.0) then
-          edge_data(e) = -1
+          edge_flag(e) = -1
 
         else
           print '(a,99f12.3)', 'BAD', norm2(vec_ef(1:3)),       &
@@ -126,9 +126,9 @@
   !-------------------------------------------------------------------!
   do e = 1, Grid % n_edges
     if( sum(Grid % edges_bc(1:Grid % n_bnd_regions, e)) .gt. 1 ) then
-      if(edge_data(e) .eq. 0) then  ! hasn't been marked yet
+      if(edge_flag(e) .eq. 0) then  ! hasn't been marked yet
         cnt = cnt + 1
-        edge_data(e) = 1
+        edge_flag(e) = 1
       end if
     end if
   end do

--- a/Sources/Convert/Convert_Mod/Save_Fluent.f90
+++ b/Sources/Convert/Convert_Mod/Save_Fluent.f90
@@ -34,19 +34,21 @@
 # endif
 !------------------------------[Local parameters]------------------------------!
   integer, parameter :: MIXED_ZONE = 0
-  integer, parameter :: CELL_TRI   = 1
-  integer, parameter :: CELL_TETRA = 2
-  integer, parameter :: CELL_QUAD  = 3
+! integer, parameter :: CELL_TRI   = 1  ! unused, like the others ...
+  integer, parameter :: CELL_TETRA = 2  ! ... whic are commented
+! integer, parameter :: CELL_QUAD  = 3
   integer, parameter :: CELL_HEXA  = 4
   integer, parameter :: CELL_PYRA  = 5
   integer, parameter :: CELL_WEDGE = 6
   integer, parameter :: CELL_POLY  = 7
-  integer, parameter :: FACE_TRI   = 3
-  integer, parameter :: FACE_QUAD  = 4
-  integer, parameter :: FACE_POLY  = 5  ! an educated guess, but seems good
+! integer, parameter :: FACE_TRI   = 3
+! integer, parameter :: FACE_QUAD  = 4
+! integer, parameter :: FACE_POLY  = 5  ! an educated guess, but seems good
 !-----------------------------------[Locals]-----------------------------------!
   character(SL) :: file_name
   integer       :: fu, n, c, i_nod, s, c1, c2, reg, reg_type, reg_zone
+!------------------------[Avoid unused parent warning]-------------------------!
+  Unused(Convert)
 !==============================================================================!
 
   call Profiler % Start('Save_Fluent')

--- a/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
+++ b/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
@@ -44,6 +44,7 @@
 !-----------------------------------[Locals]-----------------------------------!
   integer              :: i, j, m, n, nn, cnt, cl_a, cl_b
   integer              :: max_loc(2), conc_n
+  logical              :: found
   real                 :: normal_p(3), center_p(3), x_p(3), y_p(3), sense(3)
   real                 :: conc_xn, conc_yn, conc_zn
   real                 :: prod(3), prod_mag
@@ -53,7 +54,6 @@
   integer, allocatable :: order(:)
 !------------------------[Avoid unused parent warning]-------------------------!
   Unused(Convert)
-  Unused(conc_link_cnt)
 !==============================================================================!
 
   ! Take alias
@@ -82,11 +82,21 @@
   do i = 1, nn
     n = Grid % faces_n(i, s)
 
-    ! Do as you did in previous version, just take the first concave link
-    ! (I made an attempt to take into consideration only nodes which do
-    !  belong to the face under consideration, but it made matters worse.)
-    cl_a = concave_link(1, n)
-    cl_b = concave_link(2, n)
+    ! Search for the concave link pair (cl_a and cl_b) which is on the face
+    if(conc_link_cnt(n) .ge. 1) then
+      found = .false.  ! initialize found
+      do j = 1, conc_link_cnt(n)
+        cl_a = concave_link(j*2-1, n)
+        cl_b = concave_link(j*2,   n)
+        if(      (any(Grid % faces_n(1:nn, s) .eq. cl_a))  &
+           .and. (any(Grid % faces_n(1:nn, s) .eq. cl_b))  ) then
+          found = .true.
+          exit
+        end if
+      end do
+
+      Assert(found)  ! make sure it is found
+    end if
 
     if(DEBUG) then
       if(s .eq. 726610) then  ! or some other case-dependent criterion
@@ -96,7 +106,7 @@
 
     ! Move the concave node to the position
     ! in which the face will become convex
-    if(cl_a .gt. 0 .and. cl_b .gt. 0) then
+    if(conc_link_cnt(n) .ge. 1) then
       conc_n = n
       cnt    = cnt + 1
 
@@ -123,9 +133,7 @@
   !-----------------------------------!
   !   Find the plane's center point   !
   !-----------------------------------!
-  call Grid % Faces_Center(s, center_p(1),  &
-                              center_p(2),  &
-                              center_p(3))
+  call Grid % Faces_Center(s, center_p(1), center_p(2), center_p(3))
 
   !------------------------------------------------------------------!
   !   Find nodes' relative positions to the center just calculated   !

--- a/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
+++ b/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
@@ -1,5 +1,5 @@
 !==============================================================================!
-  subroutine Sort_Face_Nodes(Convert, Grid, s, concave_link)
+  subroutine Sort_Face_Nodes(Convert, Grid, s, concave_link, conc_link_cnt)
 !------------------------------------------------------------------------------!
 !>  Designed to reorganize the nodes of a given face in a mesh structure
 !>  so that they follow a rotational (circular) order.
@@ -37,19 +37,20 @@
   class(Convert_Type) :: Convert                        !! parent class
   type(Grid_Type)     :: Grid                           !! grid being converted
   integer             :: s                              !! face number
-  integer             :: concave_link(2,Grid % n_nodes) !! concave link storage
+  integer             :: concave_link(6,Grid % n_nodes) !! concave link storage
+  integer             :: conc_link_cnt(Grid % n_nodes)  !! concave link count
+!------------------------------[Local parameters]------------------------------!
+  logical, parameter :: DEBUG = .false.
 !-----------------------------------[Locals]-----------------------------------!
-  integer              :: i, j, m, n, nn, cnt
-  real                 :: normal_p(3), center_p(3), x_p(3), y_p(3), sense(3)
+  integer              :: i, j, m, n, nn, cnt, cl_a, cl_b
   integer              :: max_loc(2), conc_n
+  real                 :: normal_p(3), center_p(3), x_p(3), y_p(3), sense(3)
   real                 :: conc_xn, conc_yn, conc_zn
   real                 :: prod(3), prod_mag
   real                 :: sumang, criter
   real,    allocatable :: rp_2d(:,:), rp_3d(:,:), np_3d(:,:), sorting(:)
   real,    allocatable :: angles(:,:)
   integer, allocatable :: order(:)
-! integer              :: k, ni, nj, nk, min_loc
-! real                 :: vec_ji(3), vec_jk(3), mag_ji, mag_jk, dot_prod
 !------------------------[Avoid unused parent warning]-------------------------!
   Unused(Convert)
 !==============================================================================!
@@ -79,7 +80,22 @@
   conc_n = 0
   do i = 1, nn
     n = Grid % faces_n(i, s)
-    if(concave_link(1, n) .gt. 0 .and. concave_link(2, n) .gt. 0) then
+
+    ! Do as you did in previous version, just take the first concave link
+    ! (I made an attempt to take into consideration only nodes which do
+    !  belong to the face under consideration, but it made matters worse.)
+    cl_a = concave_link(1, n)
+    cl_b = concave_link(2, n)
+
+    if(DEBUG) then
+      if(s .eq. 726610) then  ! or some other case-dependent criterion
+        call Grid % Save_Vtk_Face(s, "face_original", s)
+      end if
+    end if
+
+    ! Move the concave node to the position
+    ! in which the face will become convex
+    if(cl_a .gt. 0 .and. cl_b .gt. 0) then
       conc_n = n
       cnt    = cnt + 1
 
@@ -89,28 +105,26 @@
       conc_zn = Grid % zn(n)
 
       ! Move the concave node in a convex position
-      Grid % xn(n) = 0.5 * (  Grid % xn(concave_link(1, n))     &
-                            + Grid % xn(concave_link(2, n))  )
-      Grid % yn(n) = 0.5 * (  Grid % yn(concave_link(1, n))     &
-                            + Grid % yn(concave_link(2, n))  )
-      Grid % zn(n) = 0.5 * (  Grid % zn(concave_link(1, n))     &
-                            + Grid % zn(concave_link(2, n))  )
+      Grid % xn(n) = 0.5 * (Grid % xn(cl_a) + Grid % xn(cl_b))
+      Grid % yn(n) = 0.5 * (Grid % yn(cl_a) + Grid % yn(cl_b))
+      Grid % zn(n) = 0.5 * (Grid % zn(cl_a) + Grid % zn(cl_b))
     end if
   end do
   ! if(cnt .eq. 1) print *, '# Found a concave link in face', s
   ! if(cnt .eq. 2) print *, '# Found two concave links in face', s
 
+  if(DEBUG) then
+    if(s .eq. 726610) then  ! or some other case-dependent criterion
+      call Grid % Save_Vtk_Face(s, "face_shifted", s)
+    end if
+  end if
+
   !-----------------------------------!
   !   Find the plane's center point   !
   !-----------------------------------!
-  center_p(:) = 0
-  do i = 1, nn
-    n = Grid % faces_n(i, s)
-    center_p(1) = center_p(1) + Grid % xn(n)
-    center_p(2) = center_p(2) + Grid % yn(n)
-    center_p(3) = center_p(3) + Grid % zn(n)
-  end do
-  center_p(1:3) = center_p(1:3) / real(nn)
+  call Grid % Faces_Center(s, center_p(1),  &
+                              center_p(2),  &
+                              center_p(3))
 
   !------------------------------------------------------------------!
   !   Find nodes' relative positions to the center just calculated   !
@@ -140,7 +154,7 @@
     do j = i + 1, nn
       prod(1:3) = Math % Cross_Product(np_3d(1:3,i), np_3d(1:3,j))
       prod_mag = min(norm2(prod(1:3)), 1.0-MILI)
-      angles(i,j) = asin(prod_mag) * 57.2957795131
+      angles(i,j) = asin(prod_mag) * 57.2957795131  ! in degrees
       if(angles(i,j) > MILI) then
         cnt = cnt + 1
         sumang = sumang + angles(i,j)
@@ -232,6 +246,13 @@
       order(1:nn)             = cshift(order(1:nn), 1)
       Grid % faces_n(1:nn, s) = cshift(Grid % faces_n(1:nn, s), 1)
     end do
+  end if
+
+  ! Plot debugging things
+  if(DEBUG) then
+    if(s .eq. 726610) then  ! or some other case-dependent criterion
+      call Grid % Save_Vtk_Face(s, "face_sorted", s)
+    end if
   end if
 
   end subroutine

--- a/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
+++ b/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
@@ -100,7 +100,7 @@
 
     if(DEBUG) then
       if(s .eq. 726610) then  ! or some other case-dependent criterion
-        call Grid % Save_Vtk_Face(s, "face_original", s)
+        call Grid % Save_Vtk_Face(s, "face_original", s, plot_center = .true.)
       end if
     end if
 
@@ -126,7 +126,7 @@
 
   if(DEBUG) then
     if(s .eq. 726610) then  ! or some other case-dependent criterion
-      call Grid % Save_Vtk_Face(s, "face_shifted", s)
+      call Grid % Save_Vtk_Face(s, "face_shifted", s, plot_center = .true.)
     end if
   end if
 
@@ -260,7 +260,7 @@
   ! Plot debugging things
   if(DEBUG) then
     if(s .eq. 726610) then  ! or some other case-dependent criterion
-      call Grid % Save_Vtk_Face(s, "face_sorted", s)
+      call Grid % Save_Vtk_Face(s, "face_sorted", s, plot_center = .true.)
     end if
   end if
 

--- a/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
+++ b/Sources/Convert/Convert_Mod/Sort_Face_Nodes.f90
@@ -53,6 +53,7 @@
   integer, allocatable :: order(:)
 !------------------------[Avoid unused parent warning]-------------------------!
   Unused(Convert)
+  Unused(conc_link_cnt)
 !==============================================================================!
 
   ! Take alias

--- a/Sources/Convert/Main_Con.f90
+++ b/Sources/Convert/Main_Con.f90
@@ -254,6 +254,18 @@
       call Convert % Save_Fluent(Grid(g))
     end if
 
+    if(g .eq. 2) then
+      call Message % Framed(80, GREEN//"NOTE"//RESET//":",                     &
+        "Dual grid has been craeted and saved. Keep in mind, however, "    //  &
+        "that although Paraivew support polyhdral cells, its support for " //  &
+        "displaying concave cells and faces is limited. See: \n \n "       //  &
+        "https://vtk.org/doc/nightly/html/classvtkPolyhedron.html"         //  &
+        "#Limitations \n \n "                                              //  &
+        "If you are unsure whether a concave cell or face has been formed "//  &
+        "correctly, temporarily display the grid in Paraview using "       //  &
+        "wireframe representation.")
+    end if
+
     if( (g-n_grids) .eq. 0) then
       ! Create a template control file for this domain
       call Grid(g) % Write_Template_Control_File()

--- a/Sources/Convert/makefile_explicit_dependencies
+++ b/Sources/Convert/makefile_explicit_dependencies
@@ -50,6 +50,7 @@ Convert_Mod/Remove_Porosities.f90 \
 Convert_Mod/N_Sharp_Edges.f90 \
 Convert_Mod/N_Sharp_Corners.f90 \
 Convert_Mod/N_Nodes_In_Region.f90 \
+Convert_Mod/N_Nodes_At_Boundary.f90 \
 Convert_Mod/N_Edges_In_Region.f90 \
 Convert_Mod/N_Bnd_Cells_In_Region.f90 \
 Convert_Mod/Logo_Con.f90 \
@@ -77,6 +78,7 @@ Convert_Mod/Remove_Porosities.f90 \
 Convert_Mod/N_Sharp_Edges.f90 \
 Convert_Mod/N_Sharp_Corners.f90 \
 Convert_Mod/N_Nodes_In_Region.f90 \
+Convert_Mod/N_Nodes_At_Boundary.f90 \
 Convert_Mod/N_Edges_In_Region.f90 \
 Convert_Mod/N_Bnd_Cells_In_Region.f90 \
 Convert_Mod/Logo_Con.f90 \
@@ -550,6 +552,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -901,6 +904,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -994,6 +998,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1333,6 +1338,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -1664,6 +1670,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \

--- a/Sources/Divide/makefile_explicit_dependencies
+++ b/Sources/Divide/makefile_explicit_dependencies
@@ -51,6 +51,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -486,6 +487,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -837,6 +839,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -930,6 +933,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1269,6 +1273,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -1600,6 +1605,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \

--- a/Sources/Generate/makefile_explicit_dependencies
+++ b/Sources/Generate/makefile_explicit_dependencies
@@ -64,6 +64,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -152,6 +153,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -228,6 +230,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -309,6 +312,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -400,6 +404,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -825,6 +830,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1176,6 +1182,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -1269,6 +1276,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1608,6 +1616,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -1939,6 +1948,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \

--- a/Sources/Process/Cpu/Swarm_Mod/Move_Particle.f90
+++ b/Sources/Process/Cpu/Swarm_Mod/Move_Particle.f90
@@ -160,7 +160,7 @@
       vp = vp + Part % v_drw
       wp = wp + Part % v_drw
 
-    else ! normal ER-HRL with ad-hoc SGS modeling
+    else  ! normal ER-HRL with ad-hoc SGS modeling
       ! Compute wall-normal vel. at particle position from velocity gradients
       ! should create a switch for this case (SGS model is k-eps-zeta-f model
       ! itself)

--- a/Sources/Process/Cpu/Turb_Mod/Src_Vis_Spalart_Allmaras.f90
+++ b/Sources/Process/Cpu/Turb_Mod/Src_Vis_Spalart_Allmaras.f90
@@ -36,9 +36,9 @@
       dist = min(Grid % wall_dist(c), Turb % C_des * Turb % h_max(c))
     end if
 
-    !------------------------------------------------------!
-    ! This limit is important for stability of the model
-    !------------------------------------------------------!
+    !--------------------------------------------------------!
+    !   This limit is important for stability of the model   !
+    !--------------------------------------------------------!
     dist_eff = max(dist, DIST_MIN)
 
     !---------------------------------!

--- a/Sources/Process/Cpu/User_Mod/Get_User_Field_For_Saving.f90
+++ b/Sources/Process/Cpu/User_Mod/Get_User_Field_For_Saving.f90
@@ -8,7 +8,7 @@
 !                                                                              !
 !   Note: Be aware that this function is called from CPU only, at the moment   !
 !         when results are downloaded to host (CPU).  Thus, make sure that     !
-!         you send the CPU copy of the variable.
+!         you send the CPU copy of the variable.                               !
 !------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!

--- a/Sources/Process/Cpu/makefile_explicit_dependencies
+++ b/Sources/Process/Cpu/makefile_explicit_dependencies
@@ -54,6 +54,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -460,6 +461,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -825,6 +827,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1381,6 +1384,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -1648,6 +1652,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -2266,6 +2271,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -2617,6 +2623,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -2710,6 +2717,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \
@@ -3049,6 +3057,7 @@ $(DIR_SHARED)/Sort_Mod/Quick/Real_Array.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Real.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Carry_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Quick/Int_Array.f90 \
+$(DIR_SHARED)/Sort_Mod/Log_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Int_By_Index.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Two_Int.f90 \
 $(DIR_SHARED)/Sort_Mod/Heap/Two_Real_Carry_Int.f90 \
@@ -3380,6 +3389,7 @@ $(DIR_SHARED)/Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Wall_Distance.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Global_Volumes.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Faces_Surface.f90 \
+$(DIR_SHARED)/Grid_Mod/Calculate/Faces_Center.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Surfaces.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Interpolation.f90 \
 $(DIR_SHARED)/Grid_Mod/Calculate/Face_Geometry.f90 \

--- a/Sources/Shared/Const_Mod.f90
+++ b/Sources/Shared/Const_Mod.f90
@@ -121,5 +121,24 @@
   ! Steps for expanding the memory in Generate
   integer, parameter :: GROWTH_MARGIN =  131072 !! steps for expanding
                                                 !! memory in Generate
+  !---------------------!
+  !   Color constants   !
+  !---------------------!
+  character(len=1), parameter :: ESC   = achar(27)
+  character(len=4), parameter :: RESET = ESC//'[0m'
+
+  character(len=5), parameter :: RED     = ESC//'[31m'
+  character(len=5), parameter :: GREEN   = ESC//'[32m'
+  character(len=5), parameter :: YELLOW  = ESC//'[33m'
+  character(len=5), parameter :: BLUE    = ESC//'[34m'
+  character(len=5), parameter :: MAGENTA = ESC//'[35m'
+  character(len=5), parameter :: CYAN    = ESC//'[36m'
+
+  character(len=5), parameter :: BRIGHT_RED     = ESC//'[91m'
+  character(len=5), parameter :: BRIGHT_GREEN   = ESC//'[92m'
+  character(len=5), parameter :: BRIGHT_YELLOW  = ESC//'[93m'
+  character(len=5), parameter :: BRIGHT_BLUE    = ESC//'[94m'
+  character(len=5), parameter :: BRIGHT_MAGENTA = ESC//'[95m'
+  character(len=5), parameter :: BRIGHT_CYAN    = ESC//'[96m'
 
   end module

--- a/Sources/Shared/File_Mod/Open_For_Reading_Ascii.f90
+++ b/Sources/Shared/File_Mod/Open_For_Reading_Ascii.f90
@@ -23,10 +23,11 @@
 
   ! File doesn't exist
   if(.not. file_exists) then
-    call Message % Error(60, "File: " // trim(name_i)    //  &
-                             " doesn't exist!"           //  &
-                             " This error is critical."  //  &
-                             " Exiting!",                    &
+    call Message % Error(60, "File: "                          //  &
+                             BRIGHT_CYAN//trim(name_i)//RESET  //  &
+                             " doesn't exist!"                 //  &
+                             " This error is critical."        //  &
+                             " Exiting!",                          &
                              one_proc = .true.)
   end if
 
@@ -37,7 +38,8 @@
 
   ! ... and write a message about it
   if(First_Proc()) then
-    print '(a)', ' # Reading the ASCII file: ' // trim(name_i)
+    print '(a)', " # Reading the ASCII file: " //  &
+                 BRIGHT_CYAN//trim(name_i)//RESET
   end if
 
   end subroutine

--- a/Sources/Shared/File_Mod/Open_For_Reading_Binary.f90
+++ b/Sources/Shared/File_Mod/Open_For_Reading_Binary.f90
@@ -31,10 +31,11 @@
 
   ! File doesn't exist
   if(.not. file_exists) then
-    call Message % Error(60, "File: " // trim(name_i)    //  &
-                             " doesn't exist!"           //  &
-                             " This error is critical."  //  &
-                             " Exiting!",                    &
+    call Message % Error(60, "File: "                          //  &
+                             BRIGHT_CYAN//trim(name_i)//RESET  //  &
+                             " doesn't exist!"                 //  &
+                             " This error is critical."        //  &
+                             " Exiting!",                          &
                              one_proc = .true.)
   end if
 
@@ -49,7 +50,8 @@
   if(verb) then
     if(First_Proc()) then
       if(Sequential_Run()) then
-        print '(a)', ' # Reading the binary file: ' // trim(name_i)
+        print '(a)', " # Reading the binary file: "    //  &
+                     BRIGHT_CYAN//trim(name_i)//RESET
       else
         name_l = name_i
         f = index(name_i, '/')              + 1
@@ -59,8 +61,8 @@
         if(l-f .eq. 2) write(name_l(f:l), '(i3.3)') N_Procs()
         if(l-f .eq. 3) write(name_l(f:l), '(i4.4)') N_Procs()
         if(l-f .eq. 4) write(name_l(f:l), '(i5.5)') N_Procs()
-        print '(a)', ' # Reading the binary files: '  //  &
-                     trim(name_i) // ' ... ' // trim(name_l)
+        print '(a)', " # Reading the binary files: "  //  &
+                     BRIGHT_CYAN//trim(name_i)//RESET
       end if
     end if
   end if

--- a/Sources/Shared/File_Mod/Open_For_Writing_Ascii.f90
+++ b/Sources/Shared/File_Mod/Open_For_Writing_Ascii.f90
@@ -17,7 +17,8 @@
   open(newunit = file_unit, file = trim(name_o), status = 'replace')
 
   if(First_Proc()) then
-    print '(a)', ' # Creating the ASCII file: ' // trim(name_o)
+    print '(a)', " # Creating the ASCII file: "   //  &
+                 BRIGHT_CYAN//trim(name_o)//RESET
   end if
 
   end subroutine

--- a/Sources/Shared/File_Mod/Open_For_Writing_Binary.f90
+++ b/Sources/Shared/File_Mod/Open_For_Writing_Binary.f90
@@ -27,7 +27,8 @@
 
   if(First_Proc()) then
     if(Sequential_Run()) then
-      print '(a)', ' # Creating the binary file: ' // trim(name_o)
+      print '(a)', " # Creating the binary file: "  //  &
+                   BRIGHT_CYAN//trim(name_o)//RESET
     else
       name_l = name_o
       f = index(name_o, '/')              + 1
@@ -38,10 +39,13 @@
       if(l-f .eq. 3) write(name_l(f:l), '(i4.4)') N_Procs()
       if(l-f .eq. 4) write(name_l(f:l), '(i5.5)') N_Procs()
       if(trim(name_o) .eq. trim(name_l)) then  ! for creation of pvtu file
-        print '(a)', ' # Creating the binary file: ' // trim(name_o)
+        print '(a)', " # Creating the binary file: " //  &
+                     BRIGHT_CYAN//trim(name_o)//RESET
       else
-        print '(a)', ' # Creating the binary files: '  //  &
-                     trim(name_o) // ' ... ' // trim(name_l)
+        print '(a)', " # Creating the binary files: "  //  &
+                     BRIGHT_CYAN//trim(name_o)//RESET  //  &
+                     " ... "                           //  &
+                     BRIGHT_CYAN//trim(name_l)//RESET
       end if
     end if
   end if

--- a/Sources/Shared/Grid_Mod.f90
+++ b/Sources/Shared/Grid_Mod.f90
@@ -123,6 +123,9 @@
     ! (Introduced with Insert_Buildings in Convert)
     integer, allocatable :: por(:)  !! porous region to which each cell belongs
 
+    ! For each cell: is it concave?
+    logical, allocatable :: concave(:)  !! is cell concave?
+
     !-------------------------!
     !  Face-based variables   !
     !-------------------------!

--- a/Sources/Shared/Grid_Mod.f90
+++ b/Sources/Shared/Grid_Mod.f90
@@ -232,6 +232,7 @@
       procedure :: Calculate_Wall_Distance
       procedure :: Calculate_Weights_Cells_To_Nodes
       procedure :: Calculate_Weights_Nodes_To_Cells
+      procedure :: Faces_Center
       procedure :: Faces_Surface
 
       ! Determination of grid connectivities
@@ -307,8 +308,9 @@
 #   include "Grid_Mod/Calculate/Face_Centers.f90"
 #   include "Grid_Mod/Calculate/Face_Geometry.f90"
 #   include "Grid_Mod/Calculate/Face_Interpolation.f90"
-#   include "Grid_Mod/Calculate/Faces_Surface.f90"
 #   include "Grid_Mod/Calculate/Face_Surfaces.f90"
+#   include "Grid_Mod/Calculate/Faces_Center.f90"
+#   include "Grid_Mod/Calculate/Faces_Surface.f90"
 #   include "Grid_Mod/Calculate/Global_Volumes.f90"
 #   include "Grid_Mod/Calculate/Wall_Distance.f90"
 #   include "Grid_Mod/Calculate/Weights_Cells_To_Nodes.f90"

--- a/Sources/Shared/Grid_Mod/Calculate/Cell_Centers.f90
+++ b/Sources/Shared/Grid_Mod/Calculate/Cell_Centers.f90
@@ -10,22 +10,30 @@
   integer :: c, i_nod, n
 !==============================================================================!
 
-  ! (Re)initialize cell coordinates
-  Grid % xc(:) = 0.0
-  Grid % yc(:) = 0.0
-  Grid % zc(:) = 0.0
-
-  ! Compute them by adding node coordinates and dividing by their number
+  !--------------------------------------------------------------------------!
+  !   Compute them by adding node coordinates and dividing by their number   !
+  !--------------------------------------------------------------------------!
   do c = 1, Grid % n_cells
-    do i_nod = 1, abs(Grid % cells_n_nodes(c))
-      n = Grid % cells_n(i_nod, c)
-      Grid % xc(c) = Grid % xc(c) + Grid % xn(n)  &
-                   / real(abs(Grid % cells_n_nodes(c)))
-      Grid % yc(c) = Grid % yc(c) + Grid % yn(n)  &
-                   / real(abs(Grid % cells_n_nodes(c)))
-      Grid % zc(c) = Grid % zc(c) + Grid % zn(n)  &
-                   / real(abs(Grid % cells_n_nodes(c)))
-    end do
+
+    ! For concave cells, cell center was estimated in Convert_Mod/Create_Dual
+    if(.not. Grid % concave(c)) then
+
+      ! (Re)initialize cell coordinates
+      Grid % xc(c) = 0.0
+      Grid % yc(c) = 0.0
+      Grid % zc(c) = 0.0
+
+      do i_nod = 1, abs(Grid % cells_n_nodes(c))
+        n = Grid % cells_n(i_nod, c)
+        Grid % xc(c) = Grid % xc(c) + Grid % xn(n)  &
+                     / real(abs(Grid % cells_n_nodes(c)))
+        Grid % yc(c) = Grid % yc(c) + Grid % yn(n)  &
+                     / real(abs(Grid % cells_n_nodes(c)))
+        Grid % zc(c) = Grid % zc(c) + Grid % zn(n)  &
+                     / real(abs(Grid % cells_n_nodes(c)))
+      end do
+
+    end if
   end do
 
   print *, '# Cell centers calculated !'

--- a/Sources/Shared/Grid_Mod/Calculate/Faces_Center.f90
+++ b/Sources/Shared/Grid_Mod/Calculate/Faces_Center.f90
@@ -1,0 +1,34 @@
+!==============================================================================!
+  subroutine Faces_Center(Grid, s, xf, yf, zf)
+!------------------------------------------------------------------------------!
+!>  Calculate a face's center from nodal coordinates.
+!------------------------------------------------------------------------------!
+  implicit none
+!---------------------------------[Arguments]----------------------------------!
+  class(Grid_Type)    :: Grid        !! grid under consideration
+  integer, intent(in) :: s           !! face number
+  real,   intent(out) :: xf, yf, zf  !! face center cooridnates
+!-----------------------------------[Locals]-----------------------------------!
+  integer :: i_nod, n, nn
+!==============================================================================!
+
+  ! Nullify cooridinates
+  xf = 0.0
+  yf = 0.0
+  zf = 0.0
+
+  ! Copy face node coordinates to a local array for easier handling
+  do i_nod = 1, Grid % faces_n_nodes(s)  ! local node counter
+    n = Grid % faces_n(i_nod ,s)         ! global node number
+    xf = xf + Grid % xn(n)
+    yf = yf + Grid % yn(n)
+    zf = zf + Grid % zn(n)
+  end do
+
+  ! Barycenter
+  nn = Grid % faces_n_nodes(s)
+  xf = xf / real(nn)
+  yf = yf / real(nn)
+  zf = zf / real(nn)
+
+  end subroutine

--- a/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Cell.f90
+++ b/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Cell.f90
@@ -24,6 +24,8 @@
   character(*)        :: head  !! a header (title) of the file
   integer, intent(in) :: rank  !! a numerical identifier of the file (imagine
                                !! a situation in which you plot a lot of files)
+!------------------------------[Local parameters]------------------------------!
+  integer, parameter :: CENTER = 1  !! plot center (1) or not (0)
 !-----------------------------------[Locals]-----------------------------------!
   integer              :: fu, i_nod, l_nod, n, i_fac, s, ndata, npoly
   character(len=SL)    :: filename
@@ -43,7 +45,12 @@
   write(fu,'(a16)')     'DATASET POLYDATA'
 
   ! Write the points out
-  write(fu,'(a6,i7,a6)') 'POINTS', abs(Grid % cells_n_nodes(c)), ' float'
+  write(fu,'(a6,i7,a6)') 'POINTS',                               &
+                         abs(Grid % cells_n_nodes(c)) + CENTER,  &
+                         ' float'
+  if(CENTER .eq. 1) then
+    write(fu,'(3es15.6)') Grid % xc(c), Grid % yc(c), Grid % zc(c)
+  end if
   l_nod = 0
   do i_nod = 1, abs(Grid % cells_n_nodes(c))
     n = Grid % cells_n(i_nod, c)
@@ -68,7 +75,7 @@
     write(fu,'(i5)') Grid % faces_n_nodes(s)
     do i_nod = 1, Grid % faces_n_nodes(s)
       n = Grid % faces_n(i_nod, s)
-      write(fu,'(i7)') local_node(n) - 1
+      write(fu,'(i7)') local_node(n) - 1 + CENTER
     end do
   end do
 

--- a/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Cell.f90
+++ b/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Cell.f90
@@ -1,5 +1,5 @@
 !==============================================================================!
-  subroutine Save_Vtk_Cell(Grid, c, head, rank)
+  subroutine Save_Vtk_Cell(Grid, c, head, rank, plot_center)
 !------------------------------------------------------------------------------!
 !>  This subroutine, Save_Vtk_Cell, (and her sister Save_Vtk_Face) are designed
 !>  to output detailed visual representations of individual cells (or faces),
@@ -9,14 +9,6 @@
 !>  or examining how a cell (or a face) interacts with different phases in VOF
 !>  simulations with front tracking.
 !------------------------------------------------------------------------------!
-!   Functionality                                                              !
-!                                                                              !
-!   * The subroutine opens a VTK file for writing and writes the headers.      !
-!   * It writes the points (node coordinates) of the specified cell.           !
-!   * Polygons representing the cell faces and related data (such as local     !
-!     and global face numbers, surface vectors) are written.                   !
-!   * The file is then closed, completing the cell visualization process.      !
-!------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
   class(Grid_Type)    :: Grid  !! the grid containing the cell
@@ -24,10 +16,9 @@
   character(*)        :: head  !! a header (title) of the file
   integer, intent(in) :: rank  !! a numerical identifier of the file (imagine
                                !! a situation in which you plot a lot of files)
-!------------------------------[Local parameters]------------------------------!
-  integer, parameter :: CENTER = 1  !! plot center (1) or not (0)
+  logical, optional   :: plot_center  !! flag to plot also the center
 !-----------------------------------[Locals]-----------------------------------!
-  integer              :: fu, i_nod, l_nod, n, i_fac, s, ndata, npoly
+  integer              :: fu, i_nod, l_nod, n, i_fac, s, ndata, npoly, center
   character(len=SL)    :: filename
   integer, allocatable :: local_node(:)
 !==============================================================================!
@@ -35,8 +26,16 @@
   allocate(local_node(Grid % n_nodes))
   local_node(:) = 0
 
+  ! Processs optional parameter
+  center = 0
+  if(present(plot_center)) then
+    if(plot_center) center = 1
+  end if
+
+  ! Update the file name
   write(filename,'(a,"-",i9.9,".vtk")') trim(head), rank
 
+  ! Open the vtk file for writing
   open(newunit=fu, file=filename)
   write(fu,'(a26)')     '# vtk DataFile Version 2.0'
   write(fu,'(a6,i7.7)') 'File: ', rank
@@ -46,9 +45,9 @@
 
   ! Write the points out
   write(fu,'(a6,i7,a6)') 'POINTS',                               &
-                         abs(Grid % cells_n_nodes(c)) + CENTER,  &
+                         abs(Grid % cells_n_nodes(c)) + center,  &
                          ' float'
-  if(CENTER .eq. 1) then
+  if(center .eq. 1) then
     write(fu,'(3es15.6)') Grid % xc(c), Grid % yc(c), Grid % zc(c)
   end if
   l_nod = 0
@@ -75,7 +74,7 @@
     write(fu,'(i5)') Grid % faces_n_nodes(s)
     do i_nod = 1, Grid % faces_n_nodes(s)
       n = Grid % faces_n(i_nod, s)
-      write(fu,'(i7)') local_node(n) - 1 + CENTER
+      write(fu,'(i7)') local_node(n) - 1 + center
     end do
   end do
 

--- a/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Face.f90
+++ b/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Face.f90
@@ -1,5 +1,5 @@
 !==============================================================================!
-  subroutine Save_Vtk_Face(Grid, s, head, rank)
+  subroutine Save_Vtk_Face(Grid, s, head, rank, plot_center)
 !------------------------------------------------------------------------------!
 !>  This subroutine, Save_Vtk_Face, (and her sister Save_Vtk_Cell) are designed
 !>  to output detailed visual representations of individual faces (or cells),
@@ -9,11 +9,6 @@
 !>  or examining how a face (or a cell) interacts with different phases in VOF
 !>  simulations with front tracking.
 !------------------------------------------------------------------------------!
-!   * A VTK file is opened for writing, and the necessary headers are set up.  !
-!   * The subroutine writes the node coordinates of the specified face.        !
-!   * It then writes the polygon representing the face and its data.           !
-!   * The file is closed after completing the writing process.                 !
-!------------------------------------------------------------------------------!
   implicit none
 !---------------------------------[Arguments]----------------------------------!
   class(Grid_Type)    :: Grid  !! the grid containing the face
@@ -21,15 +16,22 @@
   character(*)        :: head  !! a header (title) of the file
   integer, intent(in) :: rank  !! a numerical identifier of the file (imagine
                                !! a situation in which you plot a lot of files)
-!------------------------------[Local parameters]------------------------------!
-  integer, parameter :: CENTER = 1  !! plot center (1) or not (0)
+  logical, optional   :: plot_center  !! flag to plot also the center
 !-----------------------------------[Locals]-----------------------------------!
-  integer           :: i_nod, n, fu
+  integer           :: i_nod, n, fu, center
   character(len=80) :: filename  ! don't use SL for separate compilation
 !==============================================================================!
 
+  ! Processs optional parameter
+  center = 0
+  if(present(plot_center)) then
+    if(plot_center) center = 1
+  end if
+
+  ! Update the file name
   write(filename,'(a,"-",i9.9,".vtk")') trim(head), rank
 
+  ! Open the vtk file for writing
   open(newunit=fu, file=filename)
   write(fu,'(a26)')     '# vtk DataFile Version 2.0'
   write(fu,'(a6,i7.7)') 'File: ', s
@@ -39,9 +41,9 @@
 
   ! Write the points out
   write(fu,'(a6,i7,a6)') 'POINTS',                          &
-                         Grid % faces_n_nodes(s) + CENTER,  &
+                         Grid % faces_n_nodes(s) + center,  &
                          ' float'
-  if(CENTER .eq. 1) then
+  if(center .eq. 1) then
     write(fu,'(3es15.6)') Grid % xf(s), Grid % yf(s), Grid % zf(s)
   end if
   do i_nod = 1, Grid % faces_n_nodes(s)
@@ -53,7 +55,7 @@
   write(fu,'(a8,i7,i7)') 'POLYGONS', 1, Grid % faces_n_nodes(s) + 1
   write(fu,'(i7)') Grid % faces_n_nodes(s)
   do i_nod = 1, Grid % faces_n_nodes(s)
-    write(fu,'(i7)') i_nod - 1 + CENTER
+    write(fu,'(i7)') i_nod - 1 + center
   end do
 
   ! Beginning of face data

--- a/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Face.f90
+++ b/Sources/Shared/Grid_Mod/Input_Output/Save_Vtk_Face.f90
@@ -21,6 +21,8 @@
   character(*)        :: head  !! a header (title) of the file
   integer, intent(in) :: rank  !! a numerical identifier of the file (imagine
                                !! a situation in which you plot a lot of files)
+!------------------------------[Local parameters]------------------------------!
+  integer, parameter :: CENTER = 1  !! plot center (1) or not (0)
 !-----------------------------------[Locals]-----------------------------------!
   integer           :: i_nod, n, fu
   character(len=80) :: filename  ! don't use SL for separate compilation
@@ -36,7 +38,12 @@
   write(fu,'(a16)')     'DATASET POLYDATA'
 
   ! Write the points out
-  write(fu,'(a6,i7,a6)') 'POINTS', Grid % faces_n_nodes(s), ' float'
+  write(fu,'(a6,i7,a6)') 'POINTS',                          &
+                         Grid % faces_n_nodes(s) + CENTER,  &
+                         ' float'
+  if(CENTER .eq. 1) then
+    write(fu,'(3es15.6)') Grid % xf(s), Grid % yf(s), Grid % zf(s)
+  end if
   do i_nod = 1, Grid % faces_n_nodes(s)
     n = Grid % faces_n(i_nod, s)
     write(fu,'(3es15.6)') Grid % xn(n), Grid % yn(n), Grid % zn(n)
@@ -46,7 +53,7 @@
   write(fu,'(a8,i7,i7)') 'POLYGONS', 1, Grid % faces_n_nodes(s) + 1
   write(fu,'(i7)') Grid % faces_n_nodes(s)
   do i_nod = 1, Grid % faces_n_nodes(s)
-    write(fu,'(i7)') i_nod-1
+    write(fu,'(i7)') i_nod - 1 + CENTER
   end do
 
   ! Beginning of face data

--- a/Sources/Shared/Grid_Mod/Input_Output/Save_Vtu_Cells.f90
+++ b/Sources/Shared/Grid_Mod/Input_Output/Save_Vtu_Cells.f90
@@ -262,6 +262,15 @@
   write(fu) IN_4 // '</DataArray>' // LF
   data_offset = data_offset + SP + n_cells_sub * IP  ! prepare for next
 
+  ! Cell is probably concace
+  write(str1, '(i0.0)') data_offset
+  write(fu) IN_4 // '<DataArray type='//intp               //  &
+                    ' Name="Grid Cell Maybe Concave [1]"'  //  &
+                    ' format="appended"'                   //  &
+                    ' offset="' // trim(str1) //'">'       // LF
+  write(fu) IN_4 // '</DataArray>' // LF
+  data_offset = data_offset + SP + n_cells_sub * IP  ! prepare for next
+
   !------------!
   !            !
   !   Footer   !
@@ -501,6 +510,21 @@
   do c = Cells_In_Domain()
     if(Grid % new_c(c) .ne. 0) then
       i=i+1;  i_buffer(i) = Grid % por(c)
+    end if
+  end do
+  write(fu) i_buffer(1:i)
+
+  ! Cell concavity
+  data_size = int(n_cells_sub * IP, SP)
+  write(fu) data_size
+  i = 0
+  do c = Cells_In_Domain()
+    if(Grid % new_c(c) .ne. 0) then
+      if(Grid % concave(c)) then
+        i=i+1;  i_buffer(i) = 1
+      else
+        i=i+1;  i_buffer(i) = 0
+      end if
     end if
   end do
   write(fu) i_buffer(1:i)

--- a/Sources/Shared/Grid_Mod/Memory/Allocate_Cells.f90
+++ b/Sources/Shared/Grid_Mod/Memory/Allocate_Cells.f90
@@ -112,6 +112,9 @@
   ! Allocate cell-based porous regions
   call Enlarge % Array_Int(Grid % por, i=(/-nb_m,nc_m/))
 
+  ! Allocate cell-based concave flag
+  call Enlarge % Array_Log(Grid % concave, i=(/-nb_m,nc_m/))
+
   ! Allocate processor i.d.
   call Enlarge % Array_Int(Grid % Comm % cell_proc, i=(/-nb_m,nc_m/))
   call Enlarge % Array_Int(Grid % Comm % cell_glo,  i=(/-nb_m,nc_m/))

--- a/Sources/Shared/Grid_Mod/Sorting/Sort_Cells_By_Coordinates.f90
+++ b/Sources/Shared/Grid_Mod/Sorting/Sort_Cells_By_Coordinates.f90
@@ -163,6 +163,7 @@
   call Sort % Real_By_Index(nc, Grid % iyz      (1), Grid % new_c(1))
   call Sort % Real_By_Index(nc, Grid % wall_dist(1), Grid % new_c(1))
   call Sort % Int_By_Index (nc, Grid % por      (1), Grid % new_c(1))
+  call Sort % Log_By_Index (nc, Grid % concave  (1), Grid % new_c(1))
 
   !--------------------------------------------!
   !   Find out distance between cell indices   !

--- a/Sources/Shared/Message_Mod/Error.f90
+++ b/Sources/Shared/Message_Mod/Error.f90
@@ -43,12 +43,12 @@
   !   Form the header for error   !
   !-------------------------------!
   if(present(file) .and. present(line)) then
-    write(header_text, '(a,i3)')  "ERROR in file: " // file //  &
-                                  " at line: ", line
+    write(header_text, '(a,i3)')  RED//"ERROR"//RESET//" in file: " //  &
+                                  file // " at line: ", line
   else if(present(file)) then
-    write(header_text, '(a,i3)')  "ERROR in file: " // file
+    write(header_text, '(a,i3)')  RED//"ERROR"//RESET//" in file: " // file
   else
-    write(header_text, '(a,i3)')  "ERROR!"
+    write(header_text, '(a,i3)')  RED//"ERROR"//RESET//"!"
   end if
 
   ! Adjust width, if necessary

--- a/Sources/Shared/Message_Mod/Warning.f90
+++ b/Sources/Shared/Message_Mod/Warning.f90
@@ -35,14 +35,16 @@
   character(DL) :: header_text
 !==============================================================================!
 
-  !-------------------------------!
-  !   Form the header for error   !
-  !-------------------------------!
+  !---------------------------------!
+  !   Form the header for warning   !
+  !---------------------------------!
   if(present(file) .and. present(line)) then
-    write(header_text, '(a,i3)')  "WARNING in file: " // file //  &
-                                  " on line: ", line
+    write(header_text, '(a,i3)')  YELLOW//"WARNING"//RESET//" in file: " //  &
+                                  file // " at line: ", line
+  else if(present(file)) then
+    write(header_text, '(a,i3)')  YELLOW//"WARNING"//RESET//" in file: " // file
   else
-    write(header_text, '(a,i3)')  "WARNING!"
+    write(header_text, '(a,i3)')  YELLOW//"WARNING"//RESET//"!"
   end if
 
   ! Adjust width, if necessary

--- a/Sources/Shared/Porosity_Mod/Create_Porosity.f90
+++ b/Sources/Shared/Porosity_Mod/Create_Porosity.f90
@@ -5,9 +5,13 @@
   type(Grid_Type), target :: Grid
 !-----------------------------------[Locals]-----------------------------------!
   integer       :: reg, n, c
+
+  ! Variables used only from Process
+# if T_FLOWS_PROGRAM == 4
   logical       :: found
   character(SL) :: porous_region_rank
   character(SL) :: next_strings(MAX_STRING_ITEMS)
+# endif
 !==============================================================================!
 
   !---------------------------!

--- a/Sources/Shared/Porosity_Mod/Create_Porosity.f90
+++ b/Sources/Shared/Porosity_Mod/Create_Porosity.f90
@@ -4,10 +4,11 @@
   class(Porosity_Type)    :: Por
   type(Grid_Type), target :: Grid
 !-----------------------------------[Locals]-----------------------------------!
-  integer       :: reg, n, c
+  integer       :: reg, c
 
   ! Variables used only from Process
 # if T_FLOWS_PROGRAM == 4
+  integer       :: n
   logical       :: found
   character(SL) :: porous_region_rank
   character(SL) :: next_strings(MAX_STRING_ITEMS)

--- a/Sources/Shared/Sort_Mod.f90
+++ b/Sources/Shared/Sort_Mod.f90
@@ -31,6 +31,7 @@
       procedure :: Int_By_Index
       procedure :: Int_Carry_Int
       procedure :: Int_Carry_Real
+      procedure :: Log_By_Index
       procedure :: Real_Array
       procedure :: Real_By_Index
       procedure :: Real_Carry_Int
@@ -64,6 +65,7 @@
   contains
 
 #   include "Sort_Mod/Int_By_Index.f90"
+#   include "Sort_Mod/Log_By_Index.f90"
 #   include "Sort_Mod/Real_By_Index.f90"
 #   include "Sort_Mod/Reverse_Order_Int.f90"
 #   include "Sort_Mod/Reverse_Order_Real.f90"

--- a/Sources/Shared/Sort_Mod/Log_By_Index.f90
+++ b/Sources/Shared/Sort_Mod/Log_By_Index.f90
@@ -1,0 +1,31 @@
+!==============================================================================!
+  pure subroutine Log_By_Index(Sort, n, x, indx)
+!------------------------------------------------------------------------------!
+!>  Sorts integer array x according to index.
+!------------------------------------------------------------------------------!
+  implicit none
+!---------------------------------[Arguments]----------------------------------!
+  class(Sort_Type), intent(in)    :: Sort     !! parent class
+  integer,          intent(in)    :: n        !! array size
+  logical,          intent(inout) :: x(n)     !! array to be sorted
+  integer,          intent(in)    :: indx(n)  !! index for sorting
+!-----------------------------------[Locals]-----------------------------------!
+  integer              :: i        !! loop variable
+  logical, allocatable :: work(:)  !! work array
+!------------------------[Avoid unused parent warning]-------------------------!
+  Unused(Sort)
+!==============================================================================!
+
+  allocate(work(n)); work = .false.
+
+  do i = 1, n
+    work(indx(i)) = x(i)
+  end do
+
+  do i = 1, n
+    x(i) = work(i)
+  end do
+
+  deallocate(work)
+
+  end subroutine

--- a/Sources/Shared/Tokenizer_Mod.f90
+++ b/Sources/Shared/Tokenizer_Mod.f90
@@ -30,7 +30,8 @@
     character(1)            :: first, last         !! the first and the last
                                                    !! character in the whole
     contains
-      procedure :: Parse  !! procedure to tokenize the string stored in whole
+      procedure :: Parse    !! procedure to tokenize the string
+      procedure :: Is_Char  !! determines if token is printable
 
   end type
 
@@ -42,5 +43,6 @@
   contains
 
 #   include "Tokenizer_Mod/Parse.f90"
+#   include "Tokenizer_Mod/Is_Char.f90"
 
   end module

--- a/Sources/Shared/Tokenizer_Mod/Is_Char.f90
+++ b/Sources/Shared/Tokenizer_Mod/Is_Char.f90
@@ -1,0 +1,31 @@
+
+!==============================================================================!
+  pure logical function Is_Char(Tok, ch)
+!------------------------------------------------------------------------------!
+!>  Checks whether a character should be treated as part of a token when
+!>  tokenizing strings.
+!>
+!>  Normally, printable characters are considered token characters, while
+!>  control characters and blanks are treated as separators.  However, the ANSI
+!>  escape character ESC is treated as a token character as well.  This allows
+!>  coloured terminal strings, such as ESC//"[96m", to pass through the
+!>  tokenizer without losing the ESC character.
+!>
+!>  Note that ANSI colour sequences are still counted as ordinary characters
+!>  when estimating string length.  This slightly over-estimates the visible
+!>  length of coloured strings, but this is acceptable for formatted diagnostic
+!>  messages.
+!------------------------------------------------------------------------------!
+  implicit none
+!---------------------------------[Arguments]----------------------------------!
+  class(Tokenizer_Type), intent(in)   :: Tok  !! parent class containing the
+                                              !! string to be tokenized
+  character(len=1), intent(in)        :: ch   !! input character
+!==============================================================================!
+
+  ! Normal printable characters are token characters.
+  ! ANSI ESC is also a token character, even though ASCII 27 < '!'.
+  Is_Char = iachar(ch) >= iachar('!') .or. iachar(ch) == 27
+
+  end function
+

--- a/Sources/Shared/Tokenizer_Mod/Parse.f90
+++ b/Sources/Shared/Tokenizer_Mod/Parse.f90
@@ -44,19 +44,20 @@
 
   ! Then parse
   Tok % n_tokens = 0
-  if(Tok % whole(1:1) >= '!') then
+  if(Tok % Is_Char(Tok % whole(1:1))) then
     Tok % n_tokens = 1
-    Tok % s(1)=1
+    Tok % s(1) = 1
   end if
+
   do i = 1, len(Tok % whole) - 1
-    if( Tok % whole(i:  i  ) <  '!' .and.  &
-        Tok % whole(i+1:i+1) >= '!') then
+    if( .not. Tok % Is_Char(Tok % whole(i  :i  )) .and.  &
+              Tok % Is_Char(Tok % whole(i+1:i+1)) ) then
       Tok % n_tokens = Tok % n_tokens + 1
       Assert(Tok % n_tokens <= MAX_TOKENS)
-      Tok % s(Tok % n_tokens) = i+1
+      Tok % s(Tok % n_tokens) = i + 1
     end if
-    if( Tok % whole(i  :i  ) >= '!' .and.  &
-        Tok % whole(i+1:i+1) <  '!') then
+    if(       Tok % Is_Char(Tok % whole(i  :i  )) .and.  &
+        .not. Tok % Is_Char(Tok % whole(i+1:i+1)) ) then
       Tok % e(Tok % n_tokens) = i
     end if
   end do

--- a/Syntax/.vim/syntax/fortran.vim
+++ b/Syntax/.vim/syntax/fortran.vim
@@ -420,6 +420,9 @@ if b:fortran_dialect == "f08"
   syn keyword fortranConstant      MAX_N  ITERS  FOR_BUILDINGS  FOR_POROSITIES  FOR_CHIMNEYS
 " Constant from Native_Mod
   syn keyword fortranConstant      MATRIX_ONE  MATRIX_UVW  MATRIX_PP   MATRIX_T
+" Terminal colors
+  syn keyword fortranConstant      ESC  RESET  RED  GREEN  YELLOW  BLUE  MAGENTA  CYAN
+  syn keyword fortranConstant      BRIGHT_RED  BRIGHT_GREEN  BRIGHT_YELLOW  BRIGHT_BLUE  BRIGHT_MAGENTA  BRIGHT_CYAN
 " After the constants, I have alternating definitions of types and objects derived from them
   syn keyword fortranTypeTflows    Domain_Type    Point_Type     Block_Type     Line_Type         Range_Type     Read_Controls_Type
   syn keyword fortranObjectTflows  Dom            points Point   blocks         lines             ranges         Read_Control  Rc

--- a/license
+++ b/license
@@ -1,24 +1,56 @@
-MIT License
+T-FLOWS PROPRIETARY LICENSE AGREEMENT
+Version 1.0 (2024)
 
-Copyright (c) 2017 Kemal Hanjalic, Bojan Niceno, Muhamed Hadziabdic,
-                   Rustam Mullyadzhanov and Egor Palkin
+Copyright (c)
+T-Flows Development Team
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This software and all accompanying files (“Software”) are the exclusive 
+property of the T-Flows Development Team. The Software is provided under 
+a paid, time-limited commercial license.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. LICENSE
+   The Licensee is granted a non-exclusive, non-transferable, 
+   time-limited right to install and use the Software strictly in 
+   accordance with the terms of the commercial license agreement issued 
+   to the Licensee.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE use OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. RESTRICTIONS
+   Without prior written permission from the T-Flows Development Team, 
+   the Licensee may NOT:
+     - copy, distribute, or publish the Software;
+     - modify, alter, translate, or create derivative works;
+     - disclose or provide access to any third party;
+     - reverse-engineer, decompile, or disassemble the Software;
+     - use the Software outside the number of CPUs/GPUs/hosts permitted 
+       in the commercial license.
+
+3. OWNERSHIP
+   All intellectual property rights in the Software remain exclusively 
+   with the T-Flows Development Team. No ownership rights are transferred 
+   to the Licensee.
+
+4. NO WARRANTY
+   The Software is provided “AS IS”, without warranty of any kind, 
+   express or implied, including but not limited to performance, 
+   correctness, non-infringement, or fitness for a particular purpose.
+
+5. LIABILITY
+   In no event shall the T-Flows Development Team be liable for any 
+   damages, whether direct, indirect, incidental, or consequential, 
+   arising from the use of the Software.
+
+6. TERMINATION
+   The License automatically terminates if the Licensee violates any 
+   term of this agreement. Upon termination, the Licensee must cease 
+   using the Software and delete all copies.
+
+7. GOVERNING LAW
+   This agreement is governed by Swiss/EU law unless otherwise specified 
+   in a separate commercial agreement.
+
+Unauthorized use of this Software constitutes a violation of 
+international copyright law.
+
 
 

--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,7 @@
     4. [Large eddy simulation over a matrix of cubes](#bench_cases_matrix)
         1. [Preparing the grid](#bench_cases_matrix_prep)
         2. [Running the case](#bench_cases_matrix_running)
-        4. [Comparing against experiments](#bench_cases_matrix_comparing)
+        3. [Comparing against experiments](#bench_cases_matrix_comparing)
     5. [Volume of fluid simulation of a rising bubble](#bench_cases_bubble)
         1. [Initialization of VOF function](#bench_cases_buble_init)
         2. [Compiling](#bench_cases_buble_compiling)
@@ -2331,7 +2331,7 @@ it is a good practice to define this point.
 #### Saving and/or exiting prematurely.
 
 For this case, we set the desired number of time steps to 6000, and we set
-saving interval to each 1200 time steps.  Tt is a big grid, and you probably
+saving interval to each 1200 time steps.  It is a big grid, and you probably
 don't want to overfill the disk.  Now imagine that you are curious to see the
 results before time step reaches the prescribed interval.  (That is, in
 essence, not a bad idea, as you can use to make sure results are not marred


### PR DESCRIPTION
Hello Hamo,


With this pull request, I would like to merge the latest fixes I introduced into Convert module.  I am talking about the boundary faces with wrong signs which were result of the cell centers happened to be outside of concave cells.  After fixing concave cell centers, I went on to improve the handling of concave faces too, fixed a couple of issues with sharp corners and finally introduced terminal colors in output.

I highly doubt this changes can interfere with anything you did in the other modules in the meantime.